### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that connects Claude with Todoist for complete task and project management through natural language.
 
+<a href="https://glama.ai/mcp/servers/@greirson/mcp-todoist">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@greirson/mcp-todoist/badge" alt="Todoist Server MCP server" />
+</a>
+
 ## Quick Start
 
 1. Install: `npm install -g @greirson/mcp-todoist`


### PR DESCRIPTION
This PR adds a badge for the [Todoist MCP Server](https://glama.ai/mcp/servers/@greirson/mcp-todoist) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@greirson/mcp-todoist">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@greirson/mcp-todoist/badge" alt="Todoist Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.