### PR TITLE
feat: add full section management CRUD operations (Phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.10] - 2026-01-15
+## [0.9.0] - 2026-01-15
+
+### Added
+- **Full Section Management (Phase 7)**: Complete CRUD operations for sections
+  - **todoist_section_update**: Update section names with support for both ID and name-based lookup
+  - **todoist_section_delete**: Delete sections (and all contained tasks) by ID or name search
+  - **Section ordering**: Added `order` parameter to `todoist_section_create` for controlling section position
+  - **Name-based operations**: Both update and delete support case-insensitive partial name matching with optional project filtering
+  - **Ambiguity handling**: Clear error messages when multiple sections match a search term
+- **Section Test Suite**: Comprehensive tests in `src/handlers/test-handlers-enhanced/section-tests.ts` covering:
+  - Section creation with ordering
+  - Section retrieval by project
+  - Section update by ID
+  - Section update by name
+  - Section deletion with cleanup
 
 ### Changed
+- Total MCP tools increased from 28 to 30
+- Enhanced testing infrastructure: 5 test suites (Task, Subtask, Label, Section, Bulk Operations) with 23+ tests
 - **Dependency Updates**: Updated all dependencies to latest versions
   - Core dependencies:
     - `@doist/todoist-api-typescript`: 5.1.1 -> 5.5.1 (new Todoist API features)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ The codebase follows a clean, domain-driven architecture with focused modules fo
 
 ### Tool Architecture
 
-The server exposes 28 tools organized by entity type with standardized naming convention using underscores (MCP-compliant):
+The server exposes 30 tools organized by entity type with standardized naming convention using underscores (MCP-compliant):
 
 **Task Management:**
 - `todoist_task_create` - Creates new tasks with full attribute support
@@ -111,8 +111,10 @@ The server exposes 28 tools organized by entity type with standardized naming co
 - `todoist_project_get` - Lists all projects with their IDs and names
 
 **Section Management:**
-- `todoist_section_create` - Creates sections within projects
+- `todoist_section_create` - Creates sections within projects with optional ordering
 - `todoist_section_get` - Lists sections within projects
+- `todoist_section_update` - Updates section names by ID or name search
+- `todoist_section_delete` - Deletes sections and all contained tasks by ID or name search
 
 **Testing Infrastructure:**
 - `todoist_test_connection` - Quick API token validation and connection test
@@ -180,7 +182,7 @@ Complete simulation framework for safe testing and validation:
 - **Mock Response Generation**: Returns realistic mock data with generated IDs for mutation operations
 - **Detailed Logging**: Clear `[DRY-RUN]` prefixes show exactly what operations would perform
 - **Factory Pattern**: `createTodoistClient()` function automatically wraps client based on environment
-- **Comprehensive Coverage**: All 28 MCP tools support dry-run mode with full validation
+- **Comprehensive Coverage**: All 30 MCP tools support dry-run mode with full validation
 - **Type Safety**: Full TypeScript support with proper type definitions for all dry-run operations
 
 ### Data Flow Pattern
@@ -273,7 +275,7 @@ Due to evolving Todoist API types, the codebase uses defensive programming patte
 - **Cache Strategy**: GET operations are cached for 30 seconds; mutation operations (create/update/delete) clear the cache
 - **Dry-Run Mode**: Enable with `DRYRUN=true` environment variable for safe testing and validation
   - Uses real API data for validation while simulating mutations
-  - All 28 MCP tools support dry-run mode with comprehensive logging
+  - All 30 MCP tools support dry-run mode with comprehensive logging
   - Perfect for testing automations, learning the API, and safe experimentation
 - **Task Search**: Update/delete/complete operations support both:
   - **Task ID**: Direct lookup by ID (more reliable, takes precedence)
@@ -316,10 +318,17 @@ The codebase includes a comprehensive development plan in `todoist-mcp-dev-prd.m
 - ✅ **Dry-Run Mode Implementation**: Complete simulation framework for safe testing and validation
   - ✅ **DryRunWrapper Architecture**: Created `src/utils/dry-run-wrapper.ts` for operation simulation
   - ✅ **Environment Configuration**: Enabled via `DRYRUN=true` environment variable
-  - ✅ **Comprehensive Tool Support**: All 28 MCP tools support dry-run mode with full validation
+  - ✅ **Comprehensive Tool Support**: All 30 MCP tools support dry-run mode with full validation
   - ✅ **Real Data Validation**: Uses actual API calls to validate while simulating mutations
   - ✅ **Factory Pattern Integration**: `createTodoistClient()` automatically handles dry-run wrapping
   - ✅ **Test Coverage**: Comprehensive test suite in `src/__tests__/dry-run-wrapper.test.ts`
+
+- **Phase 7**: Full Section Management (v0.9.0) - Complete CRUD operations for sections
+  - **Section Update**: New `todoist_section_update` tool with name-based and ID-based lookup
+  - **Section Delete**: New `todoist_section_delete` tool with cascade deletion of contained tasks
+  - **Section Ordering**: Added `order` parameter to `todoist_section_create` tool
+  - **Enhanced Testing**: Created `src/handlers/test-handlers-enhanced/section-tests.ts` with 5 section tests
+  - **New MCP Tools**: Added 2 section management tools (total: 30 tools)
 
 **Planned Future Phases:**
 - **Phase 4**: Duplicate Detection - Smart task deduplication using similarity algorithms

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Remove the `DRYRUN` environment variable or set it to `false`, then restart Clau
 
 ## Tools Overview
 
-The server provides 28 tools organized by entity type:
+The server provides 30 tools organized by entity type:
 
 ### Task Management
 - **Todoist Task Create**: Create new tasks with full attribute support
@@ -261,8 +261,10 @@ The server provides 28 tools organized by entity type:
 - **Todoist Project Get**: List all projects with their IDs and names
 
 ### Section Management
-- **Todoist Section Create**: Create sections within projects
+- **Todoist Section Create**: Create sections within projects with optional ordering
 - **Todoist Section Get**: List sections within projects
+- **Todoist Section Update**: Update section names (by ID or partial name search)
+- **Todoist Section Delete**: Delete sections and all contained tasks (by ID or partial name search)
 
 ### Testing & Validation
 - **Todoist Test Connection**: Validate API token and test connectivity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@greirson/mcp-todoist",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@greirson/mcp-todoist",
-      "version": "0.8.10",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greirson/mcp-todoist",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "description": "MCP server for Todoist API",
   "main": "dist/index.js",
   "module": "./src/index.ts",

--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -3,11 +3,14 @@ import {
   CreateProjectArgs,
   GetSectionsArgs,
   CreateSectionArgs,
+  UpdateSectionArgs,
+  SectionIdentifierArgs,
   TodoistProjectData,
   TodoistProject,
   TodoistSection,
 } from "../types.js";
 import { extractArrayFromResponse } from "../utils/api-helpers.js";
+import { ValidationError } from "../errors.js";
 
 export async function handleGetProjects(
   todoistClient: TodoistApi
@@ -77,10 +80,111 @@ export async function handleCreateSection(
   todoistClient: TodoistApi,
   args: CreateSectionArgs
 ): Promise<string> {
-  const section = await todoistClient.addSection({
+  const sectionData: { name: string; projectId: string; order?: number } = {
     name: args.name,
     projectId: args.project_id,
+  };
+
+  if (args.order !== undefined) {
+    sectionData.order = args.order;
+  }
+
+  const section = await todoistClient.addSection(sectionData);
+
+  return `Section created:\nName: ${section.name}\nID: ${section.id}\nProject ID: ${section.projectId}${
+    section.sectionOrder !== undefined ? `\nOrder: ${section.sectionOrder}` : ""
+  }`;
+}
+
+/**
+ * Helper function to find a section by ID or name
+ */
+async function findSection(
+  todoistClient: TodoistApi,
+  args: SectionIdentifierArgs
+): Promise<TodoistSection> {
+  // If section_id is provided, fetch directly
+  if (args.section_id) {
+    const section = await todoistClient.getSection(args.section_id);
+    return {
+      id: section.id,
+      name: section.name,
+      projectId: section.projectId,
+    };
+  }
+
+  // Otherwise, search by name
+  if (!args.section_name) {
+    throw new ValidationError(
+      "Either section_id or section_name must be provided"
+    );
+  }
+
+  // Get sections, optionally filtered by project
+  const getSectionsArgs = args.project_id ? { projectId: args.project_id } : {};
+  const result = await todoistClient.getSections(
+    getSectionsArgs as Parameters<typeof todoistClient.getSections>[0]
+  );
+  const sections = extractArrayFromResponse<TodoistSection>(result);
+
+  // Case-insensitive partial match
+  const searchTerm = args.section_name.toLowerCase();
+  const matchingSections = sections.filter((section: TodoistSection) =>
+    section.name.toLowerCase().includes(searchTerm)
+  );
+
+  if (matchingSections.length === 0) {
+    const projectContext = args.project_id
+      ? ` in project ${args.project_id}`
+      : "";
+    throw new ValidationError(
+      `No section found matching "${args.section_name}"${projectContext}`
+    );
+  }
+
+  if (matchingSections.length > 1) {
+    const sectionList = matchingSections
+      .map(
+        (s: TodoistSection) =>
+          `- ${s.name} (ID: ${s.id}, Project ID: ${s.projectId})`
+      )
+      .join("\n");
+    throw new ValidationError(
+      `Multiple sections found matching "${args.section_name}". Please be more specific or use section_id:\n${sectionList}`
+    );
+  }
+
+  return matchingSections[0];
+}
+
+export async function handleUpdateSection(
+  todoistClient: TodoistApi,
+  args: UpdateSectionArgs
+): Promise<string> {
+  // Find the section
+  const section = await findSection(todoistClient, args);
+
+  // Build update data - API only supports updating name
+  if (!args.name) {
+    throw new ValidationError("No updates provided. 'name' is required.");
+  }
+
+  const updatedSection = await todoistClient.updateSection(section.id, {
+    name: args.name,
   });
 
-  return `Section created:\nName: ${section.name}\nID: ${section.id}\nProject ID: ${section.projectId}`;
+  return `Section updated:\nID: ${updatedSection.id}\nOld Name: ${section.name}\nNew Name: ${updatedSection.name}\nProject ID: ${updatedSection.projectId}`;
+}
+
+export async function handleDeleteSection(
+  todoistClient: TodoistApi,
+  args: SectionIdentifierArgs
+): Promise<string> {
+  // Find the section
+  const section = await findSection(todoistClient, args);
+
+  // Delete the section
+  await todoistClient.deleteSection(section.id);
+
+  return `Section deleted:\nName: ${section.name}\nID: ${section.id}\nProject ID: ${section.projectId}\n\nNote: All tasks in this section have also been deleted.`;
 }

--- a/src/handlers/test-handlers-enhanced/index.ts
+++ b/src/handlers/test-handlers-enhanced/index.ts
@@ -4,6 +4,7 @@ import { testTaskOperations } from "./task-tests.js";
 import { testSubtaskOperations } from "./subtask-tests.js";
 import { testLabelOperations } from "./label-tests.js";
 import { testBulkOperations } from "./bulk-tests.js";
+import { testSectionOperations } from "./section-tests.js";
 import { TestSuite, ComprehensiveTestReport } from "./types.js";
 
 export async function handleTestAllFeaturesEnhanced(
@@ -16,6 +17,7 @@ export async function handleTestAllFeaturesEnhanced(
   suites.push(await testTaskOperations(todoistClient));
   suites.push(await testSubtaskOperations(todoistClient));
   suites.push(await testLabelOperations(todoistClient));
+  suites.push(await testSectionOperations(todoistClient));
   suites.push(await testBulkOperations(todoistClient));
 
   // Calculate totals
@@ -52,4 +54,5 @@ export type {
 export { testTaskOperations } from "./task-tests.js";
 export { testSubtaskOperations } from "./subtask-tests.js";
 export { testLabelOperations } from "./label-tests.js";
+export { testSectionOperations } from "./section-tests.js";
 export { testBulkOperations } from "./bulk-tests.js";

--- a/src/handlers/test-handlers-enhanced/section-tests.ts
+++ b/src/handlers/test-handlers-enhanced/section-tests.ts
@@ -1,0 +1,216 @@
+// Section operations testing module
+import { TodoistApi } from "@doist/todoist-api-typescript";
+import {
+  handleGetSections,
+  handleCreateSection,
+  handleUpdateSection,
+  handleDeleteSection,
+  handleGetProjects,
+} from "../project-handlers.js";
+import { TestSuite, EnhancedTestResult, generateTestData } from "./types.js";
+
+export async function testSectionOperations(
+  todoistClient: TodoistApi
+): Promise<TestSuite> {
+  const tests: EnhancedTestResult[] = [];
+  const startTime = Date.now();
+  const testData = generateTestData();
+  let createdSectionId: string | null = null;
+  let testProjectId: string | null = null;
+
+  // First, get a project to use for section tests
+  try {
+    const projectsResult = await handleGetProjects(todoistClient);
+    // Extract first project ID from result (format: "- ProjectName (ID: xxx)")
+    const idMatch = projectsResult.match(/\(ID: ([a-zA-Z0-9]+)\)/);
+    testProjectId = idMatch ? idMatch[1] : null;
+  } catch {
+    // If we can't get projects, skip section tests
+    return {
+      suiteName: "Section Operations",
+      tests: [
+        {
+          toolName: "todoist_section_*",
+          operation: "SETUP",
+          status: "skipped",
+          message: "Could not get project for section tests",
+          responseTime: 0,
+        },
+      ],
+      totalTime: Date.now() - startTime,
+      passed: 0,
+      failed: 0,
+      skipped: 1,
+    };
+  }
+
+  if (!testProjectId) {
+    return {
+      suiteName: "Section Operations",
+      tests: [
+        {
+          toolName: "todoist_section_*",
+          operation: "SETUP",
+          status: "skipped",
+          message: "No project available for section tests",
+          responseTime: 0,
+        },
+      ],
+      totalTime: Date.now() - startTime,
+      passed: 0,
+      failed: 0,
+      skipped: 1,
+    };
+  }
+
+  // Test 1: Create Section
+  const createStart = Date.now();
+  try {
+    const createResult = await handleCreateSection(todoistClient, {
+      name: testData.sectionName,
+      project_id: testProjectId,
+      order: 1,
+    });
+
+    // Extract section ID from result
+    const idMatch = createResult.match(/ID: ([a-zA-Z0-9]+)/);
+    createdSectionId = idMatch ? idMatch[1] : null;
+
+    tests.push({
+      toolName: "todoist_section_create",
+      operation: "CREATE",
+      status: "success",
+      message: "Successfully created section",
+      responseTime: Date.now() - createStart,
+      details: { sectionId: createdSectionId, projectId: testProjectId },
+    });
+  } catch (error) {
+    tests.push({
+      toolName: "todoist_section_create",
+      operation: "CREATE",
+      status: "error",
+      message: "Failed to create section",
+      responseTime: Date.now() - createStart,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+
+  // Test 2: Get Sections
+  const getStart = Date.now();
+  try {
+    const sections = await handleGetSections(todoistClient, {
+      project_id: testProjectId,
+    });
+    tests.push({
+      toolName: "todoist_section_get",
+      operation: "READ",
+      status: "success",
+      message: "Successfully retrieved sections",
+      responseTime: Date.now() - getStart,
+      details: { sectionCount: sections.split("\n").length - 1 },
+    });
+  } catch (error) {
+    tests.push({
+      toolName: "todoist_section_get",
+      operation: "READ",
+      status: "error",
+      message: "Failed to retrieve sections",
+      responseTime: Date.now() - getStart,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+
+  // Test 3: Update Section by ID
+  if (createdSectionId) {
+    const updateStart = Date.now();
+    try {
+      await handleUpdateSection(todoistClient, {
+        section_id: createdSectionId,
+        name: `${testData.sectionName} Updated`,
+      });
+      tests.push({
+        toolName: "todoist_section_update",
+        operation: "UPDATE",
+        status: "success",
+        message: "Successfully updated section by ID",
+        responseTime: Date.now() - updateStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "todoist_section_update",
+        operation: "UPDATE",
+        status: "error",
+        message: "Failed to update section",
+        responseTime: Date.now() - updateStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  // Test 4: Update Section by Name
+  if (createdSectionId) {
+    const updateByNameStart = Date.now();
+    try {
+      await handleUpdateSection(todoistClient, {
+        section_name: `${testData.sectionName} Updated`,
+        project_id: testProjectId,
+        name: `${testData.sectionName} Final`,
+      });
+      tests.push({
+        toolName: "todoist_section_update",
+        operation: "UPDATE_BY_NAME",
+        status: "success",
+        message: "Successfully updated section by name",
+        responseTime: Date.now() - updateByNameStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "todoist_section_update",
+        operation: "UPDATE_BY_NAME",
+        status: "error",
+        message: "Failed to update section by name",
+        responseTime: Date.now() - updateByNameStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  // Test 5: Delete Section
+  if (createdSectionId) {
+    const deleteStart = Date.now();
+    try {
+      await handleDeleteSection(todoistClient, {
+        section_id: createdSectionId,
+      });
+      tests.push({
+        toolName: "todoist_section_delete",
+        operation: "DELETE",
+        status: "success",
+        message: "Successfully deleted section",
+        responseTime: Date.now() - deleteStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "todoist_section_delete",
+        operation: "DELETE",
+        status: "error",
+        message: "Failed to delete section",
+        responseTime: Date.now() - deleteStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  const passed = tests.filter((t) => t.status === "success").length;
+  const failed = tests.filter((t) => t.status === "error").length;
+  const skipped = tests.filter((t) => t.status === "skipped").length;
+
+  return {
+    suiteName: "Section Operations",
+    tests,
+    totalTime: Date.now() - startTime,
+    passed,
+    failed,
+    skipped,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import {
   isGetSectionsArgs,
   isCreateProjectArgs,
   isCreateSectionArgs,
+  isUpdateSectionArgs,
+  isSectionIdentifierArgs,
   isBulkCreateTasksArgs,
   isBulkUpdateTasksArgs,
   isBulkTaskFilterArgs,
@@ -54,6 +56,8 @@ import {
   handleGetSections,
   handleCreateProject,
   handleCreateSection,
+  handleUpdateSection,
+  handleDeleteSection,
 } from "./handlers/project-handlers.js";
 import {
   handleCreateComment,
@@ -108,7 +112,7 @@ function formatTaskHierarchy(hierarchy: TaskHierarchy): string {
 const server = new Server(
   {
     name: "todoist-mcp-server",
-    version: "0.8.1",
+    version: "0.9.0",
   },
   {
     capabilities: {
@@ -207,6 +211,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new Error("Invalid arguments for todoist_section_create");
         }
         result = await handleCreateSection(apiClient, args);
+        break;
+
+      case "todoist_section_update":
+        if (!isUpdateSectionArgs(args)) {
+          throw new Error("Invalid arguments for todoist_section_update");
+        }
+        result = await handleUpdateSection(apiClient, args);
+        break;
+
+      case "todoist_section_delete":
+        if (!isSectionIdentifierArgs(args)) {
+          throw new Error("Invalid arguments for todoist_section_delete");
+        }
+        result = await handleDeleteSection(apiClient, args);
         break;
 
       case "todoist_tasks_bulk_create":

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,6 +40,8 @@ export {
   GET_SECTIONS_TOOL,
   CREATE_PROJECT_TOOL,
   CREATE_SECTION_TOOL,
+  UPDATE_SECTION_TOOL,
+  DELETE_SECTION_TOOL,
 } from "./project-tools.js";
 
 export { CREATE_COMMENT_TOOL, GET_COMMENTS_TOOL } from "./comment-tools.js";

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -64,8 +64,71 @@ export const CREATE_SECTION_TOOL: Tool = {
         type: "string",
         description: "Project ID where the section will be created",
       },
+      order: {
+        type: "number",
+        description:
+          "Order of the section within the project (optional, lower values appear first)",
+      },
     },
     required: ["name", "project_id"],
+  },
+};
+
+export const UPDATE_SECTION_TOOL: Tool = {
+  name: "todoist_section_update",
+  description:
+    "Update an existing section in Todoist. Can update name by section ID or section name search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      section_id: {
+        type: "string",
+        description:
+          "Section ID to update (takes precedence over section_name if both provided)",
+      },
+      section_name: {
+        type: "string",
+        description:
+          "Section name to search for (case-insensitive partial match)",
+      },
+      project_id: {
+        type: "string",
+        description:
+          "Project ID to narrow down section search when using section_name",
+      },
+      name: {
+        type: "string",
+        description: "New name for the section",
+      },
+    },
+    required: [],
+  },
+};
+
+export const DELETE_SECTION_TOOL: Tool = {
+  name: "todoist_section_delete",
+  description:
+    "Delete a section and all its tasks from Todoist. Can delete by section ID or section name search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      section_id: {
+        type: "string",
+        description:
+          "Section ID to delete (takes precedence over section_name if both provided)",
+      },
+      section_name: {
+        type: "string",
+        description:
+          "Section name to search for (case-insensitive partial match)",
+      },
+      project_id: {
+        type: "string",
+        description:
+          "Project ID to narrow down section search when using section_name",
+      },
+    },
+    required: [],
   },
 };
 
@@ -74,4 +137,6 @@ export const PROJECT_TOOLS = [
   GET_SECTIONS_TOOL,
   CREATE_PROJECT_TOOL,
   CREATE_SECTION_TOOL,
+  UPDATE_SECTION_TOOL,
+  DELETE_SECTION_TOOL,
 ];

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -6,6 +6,8 @@ import {
   GetSectionsArgs,
   CreateProjectArgs,
   CreateSectionArgs,
+  UpdateSectionArgs,
+  SectionIdentifierArgs,
   BulkCreateTasksArgs,
   BulkUpdateTasksArgs,
   BulkTaskFilterArgs,
@@ -120,14 +122,57 @@ export function isCreateProjectArgs(args: unknown): args is CreateProjectArgs {
 }
 
 export function isCreateSectionArgs(args: unknown): args is CreateSectionArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
   return (
-    typeof args === "object" &&
-    args !== null &&
-    "name" in args &&
-    "project_id" in args &&
-    typeof (args as { name: string }).name === "string" &&
-    typeof (args as { project_id: string }).project_id === "string"
+    "name" in obj &&
+    "project_id" in obj &&
+    typeof obj.name === "string" &&
+    typeof obj.project_id === "string" &&
+    (obj.order === undefined || typeof obj.order === "number")
   );
+}
+
+export function isUpdateSectionArgs(args: unknown): args is UpdateSectionArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+
+  // Must have either section_id or section_name
+  const hasSectionId =
+    obj.section_id !== undefined && typeof obj.section_id === "string";
+  const hasSectionName =
+    obj.section_name !== undefined && typeof obj.section_name === "string";
+
+  if (!hasSectionId && !hasSectionName) {
+    return false;
+  }
+
+  return (
+    (obj.project_id === undefined || typeof obj.project_id === "string") &&
+    (obj.name === undefined || typeof obj.name === "string")
+  );
+}
+
+export function isSectionIdentifierArgs(
+  args: unknown
+): args is SectionIdentifierArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+
+  // Must have either section_id or section_name
+  const hasSectionId =
+    obj.section_id !== undefined && typeof obj.section_id === "string";
+  const hasSectionName =
+    obj.section_name !== undefined && typeof obj.section_name === "string";
+
+  if (!hasSectionId && !hasSectionName) {
+    return false;
+  }
+
+  return obj.project_id === undefined || typeof obj.project_id === "string";
 }
 
 export function isBulkCreateTasksArgs(

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,20 @@ export interface CreateProjectArgs {
 export interface CreateSectionArgs {
   name: string;
   project_id: string;
+  order?: number;
+}
+
+export interface UpdateSectionArgs {
+  section_id?: string;
+  section_name?: string;
+  project_id?: string;
+  name?: string;
+}
+
+export interface SectionIdentifierArgs {
+  section_id?: string;
+  section_name?: string;
+  project_id?: string;
 }
 
 export interface TodoistTaskData {


### PR DESCRIPTION
## Summary
- Add complete CRUD operations for Todoist sections (Phase 7 of development roadmap)
- Introduces 2 new MCP tools, bringing total to 30 tools
- Enhances section management with flexible ID and name-based operations

## New MCP Tools
- **todoist_section_update**: Update section names by ID or partial name search
- **todoist_section_delete**: Delete sections and all contained tasks by ID or partial name search

## Enhanced Features
- Added `order` parameter to `todoist_section_create` for controlling section position
- Name-based operations with case-insensitive partial matching
- Project filtering support for section name searches
- Clear error messages when multiple sections match a search term

## Implementation Details
- Added `UpdateSectionArgs` and `SectionIdentifierArgs` types
- Created `isUpdateSectionArgs` and `isSectionIdentifierArgs` type guards
- Implemented `handleUpdateSection` and `handleDeleteSection` handlers
- Added `findSection` helper for flexible section lookup

## Test Plan
- [x] Added section-tests.ts to test-handlers-enhanced with 5 tests:
  - Section creation with ordering
  - Section retrieval by project
  - Section update by ID
  - Section update by name
  - Section deletion with cleanup
- [x] All existing tests pass (77 passed, 8 skipped)
- [x] Build succeeds with no TypeScript errors
- [x] Lint passes with only pre-existing warnings

## Test Prompt
```
Create section 'Test Section' in project X, update its name to 'Updated Section', then delete it
```

## Documentation
- Updated CHANGELOG.md with v0.9.0 release notes
- Updated README.md with new tool count (30 tools) and section management section
- Updated CLAUDE.md with tool architecture, roadmap, and Phase 7 completion