### PR TITLE
ci: add dev branch workflow for feature development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Created `dev` branch from `main` as the integration branch for feature development
- Updated CI workflow to run on both `main` and `dev` branches
- Updated CI to accept PRs targeting either `main` or `dev`
- Retargeted existing open PRs (#50, #52, #53) to merge into `dev` instead of `main`

## Branch Workflow
```
feature branches -> dev (integration) -> main (releases)
```

- **Feature branches**: All new features and fixes merge into `dev`
- **dev branch**: Integration branch where features are tested together
- **main branch**: Production-ready code only, releases triggered by version tags

## Release Process
The release workflow remains unchanged - it triggers only on `v*` tags from `main`. When ready to release:
1. Create PR from `dev` to `main`
2. After merge, tag the release on `main`
3. NPM publish triggers automatically

## Recommended Branch Protection Rules
For `dev`:
- Require PR reviews before merging
- Require CI status checks to pass

For `main`:
- Require PR reviews before merging
- Require CI status checks to pass
- Only allow merges from `dev` branch