### PR TITLE
feat: add reminder management (Phase 10) with Sync API integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-01-16
+
+### Added
+- **Phase 10: Reminder Management** - Full CRUD operations for task reminders via Todoist Sync API
+  - `todoist_reminder_get`: List all reminders, optionally filtered by task ID or name
+  - `todoist_reminder_create`: Create reminders with three types supported:
+    - `relative`: Minutes before task due date (e.g., 30 minutes before)
+    - `absolute`: Specific date/time in ISO 8601 format
+    - `location`: Geofenced reminders with lat/long and trigger conditions (on_enter/on_leave)
+  - `todoist_reminder_update`: Update existing reminder settings (type, timing, location)
+  - `todoist_reminder_delete`: Remove reminders from tasks
+  - Note: Reminders require Todoist Pro or Business plan
+
+### Technical Implementation
+- **Sync API Integration**: Uses Todoist Sync API v9 directly since REST API does not support reminders
+- **New Files**:
+  - `src/tools/reminder-tools.ts` - MCP tool definitions for 4 reminder operations
+  - `src/handlers/reminder-handlers.ts` - Business logic with Sync API integration
+  - `src/handlers/test-handlers-enhanced/reminder-tests.ts` - Comprehensive test suite
+- **Type Definitions**: Added `TodoistReminder`, `ReminderType`, `ReminderDue`, and related interfaces in `src/types.ts`
+- **Type Guards**: Added `isGetRemindersArgs`, `isCreateReminderArgs`, `isUpdateReminderArgs`, `isDeleteReminderArgs`
+- **Cache Integration**: 30-second TTL cache for reminder queries
+- **Task Resolution**: Supports both task ID and partial task name lookup for attaching reminders
+- **Error Handling**: Graceful handling of premium tier restrictions with informative messages
+
+### Changed
+- Total MCP tools increased from 32 to 36
+- Updated all documentation to reflect new tool count
+- Enhanced test framework to include reminder operations in comprehensive testing
+
 ## [0.9.1] - 2026-01-16
 
 ### Added
@@ -78,362 +108,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Hierarchy Parent Display (Issue #37)**: Fixed missing parent task information in `todoist_task_hierarchy_get`
-  - The hierarchy function now traverses upward to find parent tasks, not just children
-  - When called on a subtask, it now shows the complete hierarchy from the topmost parent
-  - Added visual indicator (`← current task`) to mark the originally requested task in the hierarchy
-  - Enhanced `TaskNode` and `TaskHierarchy` types with `isOriginalTask` and `originalTaskId` fields
-  - **Root Cause**: The function only built the tree downward from the given task, never checking for parents
-  - **Solution**: First traverse upward to find the topmost parent, then build complete tree from there
-
 - **Label Filter Fix (Issue #35)**: Fixed label filtering inconsistency in `todoist_task_get` tool
-  - The `label_id` parameter now correctly filters tasks by label, supporting:
-    - Numeric label IDs (e.g., "123")
-    - Label names (e.g., "trigger")
-    - Label names with @ prefix (e.g., "@trigger")
-  - Fixed issue where the Todoist TypeScript client's `label` parameter doesn't actually filter results
-  - Implemented client-side filtering for both `label_id` parameter and `@label` syntax in filters
-  - Added comprehensive validation for non-existent labels (returns no tasks instead of all tasks)
-  - Enhanced handling of tasks with undefined or missing labels array
-  - Added comprehensive test suite with 9 tests covering all edge cases
-  - **Root Cause**: The Todoist TypeScript client's `getTasks()` method ignores the `label` parameter due to API mismatch (expects `label_id` not `label`)
-  - **Solution**: Implemented proper client-side filtering with label resolution and caching
 
 ### Added
 - **Dry-Run Mode**: Complete simulation framework for safe testing and validation
-  - Added `DryRunWrapper` class in `src/utils/dry-run-wrapper.ts` for operation simulation
-  - Enabled via `DRYRUN=true` environment variable
-  - All 28 MCP tools support dry-run mode with comprehensive validation
-  - Uses real API data for validation while simulating mutations (create, update, delete, complete)
-  - UI responses clearly show `[DRY-RUN]` prefix when operations are simulated
-  - All logging output to stderr to maintain MCP protocol compliance (stdout for JSON-RPC only)
-  - Perfect for testing automations, learning the API, debugging, and safe experimentation
-  - Comprehensive test coverage in `src/__tests__/dry-run-wrapper.test.ts`
-
-### Technical Implementation
-- **DryRunWrapper Architecture**: Intercepts TodoistApi mutations when dry-run mode is enabled
-- **Real Data Validation**: Uses actual API calls to validate projects, tasks, sections, and labels exist
-- **Simulated Responses**: Returns realistic mock data with generated IDs for mutation operations
-- **Factory Pattern**: `createTodoistClient()` function automatically wraps client based on environment
-- **Type Safety**: Full TypeScript support with proper type definitions for all dry-run operations
-- **UI Indicators**: All handler responses prepend `[DRY-RUN]` when in dry-run mode for clear user feedback
 
 ### Security
 - **Critical Fix**: Fixed vulnerability in bulk operations where empty `content_contains` string matched ALL tasks instead of none (Issue #34)
-  - Empty or whitespace-only strings in `content_contains` now correctly match no tasks
-  - Added validation to reject empty strings with clear error messages
-  - Bulk operations now require at least one valid search criterion
-
-### Added
-- Comprehensive test suite for bulk operations empty string handling
-- Edge case tests for various whitespace characters and Unicode handling
-- Security tests for malicious input attempts
-
-### Changed
-- Enhanced `filterTasksByCriteria` to explicitly handle empty strings as "no match"
-- Improved `validateBulkSearchCriteria` with stricter validation rules
-- Better error messages guiding users on proper bulk operation usage
 
 ## [0.8.7] - 2025-01-21
 
 ### Added
 - **Task Name Search**: New `task_name` parameter for `todoist_task_get` tool enables partial text search in task content (case-insensitive)
-- **Enhanced Error Messages**: Filter parameter now returns helpful error messages for invalid Todoist filter syntax, guiding users to correct usage
-
-### Fixed
-- **Filter Parameter**: Fixed 400 errors when using plain text in `filter` parameter - now provides educational error messages explaining proper Todoist filter syntax
-- **Task Search**: Resolved issue where task search functionality was missing, preventing users from finding tasks by content
+- **Enhanced Error Messages**: Filter parameter now returns helpful error messages for invalid Todoist filter syntax
 
 ## [0.8.6] - 2025-09-19
 
 ### Added
 - `todoist_task_get` now supports `due_before` and `due_after` parameters for strict date window filtering
 
-### Changed
-- Task responses now surface full due context (date, datetime, timezone, natural phrase) to keep Claude timezone-aware
-- Bulk task operations reuse the same due-date normalization so search/update/delete/complete produce consistent results across timezones
-
-### Fixed
-- Natural-language filters (`today`, `overdue`, etc.) now route through Todoist's filter endpoint and no longer ignore date constraints
-- Explicit date filters (`due_before`, `due_after`) and label filters are respected during task retrieval
-- Bulk task filters now validate date input and honour the same strict before/after semantics as single-task queries
-
 ## [0.8.5] - 2025-09-17
 
 ### Added
 - **Enhanced Task Filtering**: Comprehensive due date filtering capabilities for bulk operations
-  - Added `due_before` and `due_after` parameters to bulk update operations for precise date range filtering
-  - Supports ISO date format (YYYY-MM-DD) filtering with strict date boundary validation
-  - Enhanced `filterTasksByCriteria()` function with robust date parsing and comparison logic
 - **Priority Mapping System**: Intelligent priority conversion between user-facing and API formats
-  - Added `priority-mapper.ts` utility with `toApiPriority()` and `fromApiPriority()` functions
-  - Converts user-friendly priority scale (1 = highest, 4 = lowest) to Todoist API scale (4 = highest, 1 = lowest)
-  - Integrated priority mapping across all task creation, update, and retrieval operations
-  - Ensures consistent priority handling throughout the entire system
 - **Comprehensive Testing Infrastructure**: Extensive test coverage for new filtering and priority features
-  - Added `task-filter.test.ts` with 203+ lines of comprehensive due date filtering tests
-  - Added `priority-mapper.test.ts` with complete priority conversion validation
-  - Added `bulk-e2e.test.ts` end-to-end testing for bulk operations with real API integration
-  - Enhanced Jest configuration for improved test execution and coverage
-
-### Enhanced
-- **Task Handlers**: Updated task creation, update, and bulk operations to use priority mapping
-- **Subtask Handlers**: Integrated priority mapping for consistent subtask priority handling
-- **Tool Definitions**: Updated task and subtask tool descriptions to reflect priority mapping
-- **API Helpers**: Enhanced response formatting to include priority mapping for display
-- **Cache Integration**: Improved cache invalidation and management for filtered operations
-
-### Technical Implementation
-- **Date Filtering**: Robust date boundary checking with `due_before` (strict less-than) and `due_after` (strict greater-than) logic
-- **Priority Consistency**: Automatic bi-directional priority conversion ensuring user-facing and API consistency
-- **Type Safety**: Enhanced TypeScript interfaces for new filtering parameters and priority handling
-- **Test Coverage**: Added 25+ new tests covering edge cases, boundary conditions, and error scenarios
-- **Performance**: Optimized filtering operations with improved date parsing and validation
-
-### Fixed
-- **Priority Display**: Tasks now consistently show priorities on user-friendly scale (1-4) regardless of API source
-- **Date Range Filtering**: Bulk operations now properly handle inclusive/exclusive date boundaries
-- **Type Validation**: Enhanced input validation for date formats and priority ranges
 
 ## [0.8.4] - 2025-08-14
 
 ### Fixed
 - **Parameter Format Compatibility**: Resolved systematic mismatch between MCP protocol (snake_case) and Todoist SDK (camelCase)
-  - Added `parameter-transformer.ts` utility for automatic parameter format conversion
-  - Fixed subtask handlers to use proper camelCase field names (parentId, projectId, dueString, sectionId)
-  - Updated task handlers to use parameter extraction helpers for both snake_case and camelCase support
-  - Removed debug logging from production code
-  - Ensures compatibility with both parameter formats for backward compatibility
 
 ## [0.8.3] - 2024-12-27
 
 ### Changed
 - **Project Name Support in Bulk Updates**: The `todoist_tasks_bulk_update` tool now supports project names in addition to project IDs
-  - Added `resolveProjectIdentifier()` helper function to resolve project names to IDs
-  - Users can now move tasks to projects using either the project ID or project name (e.g., "Backlog")
-  - The tool description has been updated to indicate that `project_id` accepts "project ID or name"
-
-### Fixed
-- Fixed error when bulk updating tasks with project names instead of IDs
 
 ## [0.8.2] - 2024-12-07
 
 ### Added
 - **Task ID Display**: All operations now include task IDs in their output for improved usability (fixes #13)
-  - `formatTaskForDisplay()` now shows tasks as: `- Task content (ID: 123456)`
-  - Task creation responses include: `Task created:\nID: 123456\nTitle: Task content...`
-  - Bulk operations show IDs in success lists: `- Task content (ID: 123456)`
-  - Task hierarchy displays include IDs: `○ Task content (ID: 123456) [50%]`
-  - Subtask operations show both task and parent IDs in responses
 - **Task ID Support**: All task operations now support querying by task ID in addition to task name
-  - `todoist_task_get` - Added `task_id` parameter to fetch specific task by ID (takes precedence over filtering)
-  - `todoist_task_update` - Added `task_id` parameter (takes precedence over `task_name`)
-  - `todoist_task_delete` - Added `task_id` parameter (takes precedence over `task_name`)
-  - `todoist_task_complete` - Added `task_id` parameter (takes precedence over `task_name`)
 - **Enhanced Filtering**: `todoist_task_get` now supports `priority` and `limit` parameters for better task filtering
-
-### Changed
-- **Output Format**: Standardized task ID display format across all operations
-- **Tool Parameters**: Made `task_name` optional in update/delete/complete operations (either `task_id` or `task_name` required)
-- **Tool Descriptions**: Updated to reflect ID-based querying capabilities
-- **Error Messages**: Updated to show whether search was by ID or name for better debugging
-
-### Fixed
-- **Issue #13**: Task IDs are now visible in all get operations and create/update responses
 
 ## [0.8.1] - 2024-12-07
 
 ### Changed
 - **Major Architectural Refactoring**: Significantly improved codebase maintainability and organization
-  - **Modular Tool Organization**: Broke out monolithic `src/tools.ts` (863 lines) into focused domain modules:
-    - `src/tools/task-tools.ts` - Task management tools (9 tools)
-    - `src/tools/subtask-tools.ts` - Subtask management tools (5 tools)
-    - `src/tools/project-tools.ts` - Project and section tools (4 tools)
-    - `src/tools/comment-tools.ts` - Comment management tools (2 tools)
-    - `src/tools/label-tools.ts` - Label management tools (5 tools)
-    - `src/tools/test-tools.ts` - Testing and validation tools (3 tools)
-    - `src/tools/index.ts` - Centralized exports with backward compatibility
-  - **Enhanced Test Modularization**: Broke out `src/handlers/test-handlers-enhanced.ts` (755 lines) into focused test suites:
-    - `src/handlers/test-handlers-enhanced/types.ts` - Common types and test utilities
-    - `src/handlers/test-handlers-enhanced/task-tests.ts` - Task CRUD operation tests
-    - `src/handlers/test-handlers-enhanced/subtask-tests.ts` - Subtask management tests
-    - `src/handlers/test-handlers-enhanced/label-tests.ts` - Label operation tests
-    - `src/handlers/test-handlers-enhanced/bulk-tests.ts` - Bulk operation tests
-    - `src/handlers/test-handlers-enhanced/index.ts` - Test orchestrator and exports
-
-### Improved
-- **Code Organization**: Each module now focuses on a single domain for better maintainability
-- **Developer Experience**: Easier navigation and reduced cognitive load with smaller, focused files
-- **Type Safety**: All TypeScript compilation errors resolved during refactoring
-- **Code Quality**: All ESLint issues resolved with clean, consistent formatting
-- **Backward Compatibility**: All existing imports and functionality preserved
-
-### Technical Benefits
-- **Maintainability**: Reduced largest files from 863 and 755 lines to focused modules under 400 lines each
-- **Testability**: Individual modules can be tested and modified in isolation
-- **Scalability**: Clear separation of concerns enables easier feature additions
-- **Code Discovery**: Developers can quickly locate relevant functionality by domain
 
 ## [0.8.0] - 2024-12-07
 
 ### Added
 - **Phase 3: Subtask Management System**: Complete hierarchical task management with parent-child relationships
-  - **Subtask Operations** (`src/handlers/subtask-handlers.ts`): Full CRUD operations for hierarchical tasks
-    - `handleCreateSubtask()` - Create subtasks under parent tasks with full attribute support
-    - `handleBulkCreateSubtasks()` - Create multiple subtasks efficiently under a parent task
-    - `handleConvertToSubtask()` - Convert existing tasks to subtasks (delete & recreate pattern)
-    - `handlePromoteSubtask()` - Promote subtasks to main tasks (remove parent relationship)
-    - `handleGetTaskHierarchy()` - Retrieve task trees with completion percentage tracking
-  - **New MCP Tools**: 5 additional tools for subtask management (total: 28 tools)
-    - `todoist_subtask_create` - Create individual subtasks
-    - `todoist_subtasks_bulk_create` - Create multiple subtasks at once
-    - `todoist_task_convert_to_subtask` - Convert tasks to subtasks
-    - `todoist_subtask_promote` - Promote subtasks to main tasks
-    - `todoist_task_hierarchy_get` - View task hierarchies with completion tracking
-  - **Enhanced Type System**: New interfaces for subtask operations and hierarchy management
-    - `CreateSubtaskArgs`, `BulkCreateSubtasksArgs`, `ConvertToSubtaskArgs`, `PromoteSubtaskArgs`
-    - `GetTaskHierarchyArgs`, `TaskNode`, `TaskHierarchy`, `ExtendedTaskNode`
-    - Updated `TodoistTask` with `parentId` and `isCompleted` properties
-    - Updated `CreateTaskArgs` with `parent_id` support
-
 - **Enhanced Testing Infrastructure**: Comprehensive CRUD testing with automatic cleanup
-  - **Robust Test Handlers** (`src/handlers/test-handlers-enhanced.ts`): Full tool validation
-    - Task Operations Suite: CREATE, READ, UPDATE, COMPLETE, DELETE (5 tests)
-    - Subtask Operations Suite: CREATE, HIERARCHY, BULK_CREATE, PROMOTE (4 tests)
-    - Label Operations Suite: CREATE, READ, UPDATE, STATS, DELETE (5 tests)
-    - Bulk Operations Suite: BULK_CREATE, BULK_UPDATE, BULK_COMPLETE, BULK_DELETE (4 tests)
-  - **Dual Testing Modes**: Basic (read-only) and Enhanced (full CRUD with cleanup)
-    - Enhanced mode parameter: `{ "mode": "enhanced" }` for comprehensive testing
-    - Automatic test data generation with timestamps for uniqueness
-    - Complete cleanup of all test data after testing
-    - Detailed test reporting with response times and success/failure metrics
-
-### Changed
-- **Tool Count**: Increased from 23 to 28 tools with new subtask management capabilities
-- **Test Coverage**: Enhanced `todoist_test_all_features` now supports both basic and enhanced testing modes
-- **API Compatibility**: Implemented workaround for Todoist API parent_id limitations using delete & recreate pattern
-- **Error Handling**: Extended error handling to support subtask-specific operations and validation
-- **Type Guards**: Added comprehensive type validation for all subtask operation parameters
-
-### Technical Implementation
-- **Hierarchical Task Building**: Recursive algorithm for building task trees with completion percentage calculation
-- **Cache Integration**: Subtask operations integrated with existing 30-second TTL caching system
-- **Validation & Security**: All subtask inputs validated using existing security framework
-- **API Response Handling**: Robust handling of various Todoist API response formats for subtask data
-- **Performance Optimization**: Efficient bulk subtask creation with sequential processing and error reporting
-
-### Documentation
-- **README Updates**: Added subtask management examples and updated tool count to 28
-- **Usage Examples**: New subtask workflow examples for natural language interaction
-- **Architecture Documentation**: Updated technical specifications in CLAUDE.md
 
 ## [0.7.0] - 2024-12-06
 
 ### Added
 - **Code Quality Improvement Phase**: Major architectural enhancements and security improvements
-  - **Shared API Utilities** (`src/utils/api-helpers.ts`): Eliminated code duplication with centralized helper functions
-    - `extractArrayFromResponse<T>()` - Handles multiple API response formats
-    - `createCacheKey()` - Standardized cache key generation
-    - `formatTaskForDisplay()` - Consistent task formatting
-    - Safe type extraction utilities and API response validation
-  - **Standardized Error Handling** (`src/utils/error-handling.ts`): Unified error management across all operations
-    - `ErrorHandler` class with context-aware error processing
-    - Specialized handlers for task/label not found errors
-    - `wrapAsync()` utility for automatic error handling
-    - Enhanced error context tracking and operation monitoring
-  - **Enhanced Input Validation & Sanitization** (`src/validation.ts`): Comprehensive security protection
-    - XSS protection through HTML escaping and script tag removal
-    - SQL injection pattern detection and prevention
-    - File upload security with MIME type restrictions
-    - URL validation with protocol restrictions (HTTP/HTTPS only)
-    - `VALIDATION_LIMITS` constants for consistent validation rules
-    - `sanitizeInput()`, `validateAndSanitizeContent()`, `validateAndSanitizeURL()` functions
-  - **Centralized Cache Management** (`src/cache.ts`): Advanced caching system with monitoring
-    - `CacheManager` singleton for coordinating multiple cache instances
-    - Cache statistics tracking with hit rates and memory usage monitoring
-    - LRU eviction with configurable size limits
-    - Automatic cleanup intervals and cache warming capabilities
-    - Health monitoring with actionable performance recommendations
-
-### Changed
-- **Enhanced Type Safety**: Replaced all `unknown` types with proper `TodoistAPIResponse<T>` interfaces
-- **Refactored Handlers**: All handlers now use shared utilities and standardized error handling
-- **Input Processing**: All user inputs are now sanitized before processing to prevent security vulnerabilities
-- **Validation Functions**: Enhanced to return sanitized values instead of void for better data flow
-- **Cache Architecture**: Task handlers migrated to use centralized cache management
-
-### Fixed
-- **Type Safety**: Resolved all TypeScript build errors and type mismatches
-- **Code Duplication**: Eliminated repeated `extractArrayFromResponse` functions across handlers
-- **Error Handling**: Standardized error patterns across all operations
-- **Linting**: Resolved all ESLint warnings and formatting issues
-
-### Security
-- **XSS Protection**: HTML entity escaping and malicious script detection
-- **Injection Prevention**: SQL injection pattern blocking and dangerous protocol filtering
-- **File Security**: MIME type validation and malicious filename detection
-- **Input Sanitization**: Control character removal and content length validation
-
-## [0.6.0] - 2024-12-06
-
-### Added
 - **Label Management System**: Complete CRUD operations for Todoist labels (Phase 2 completion)
-  - `todoist_label_get` - List all labels with IDs, names, and colors
-  - `todoist_label_create` - Create new labels with optional color, order, and favorite status
-  - `todoist_label_update` - Update existing labels by ID or name (supports all label attributes)
-  - `todoist_label_delete` - Delete labels by ID or name with confirmation
-  - `todoist_label_stats` - Advanced usage statistics with completion rates and last usage dates
-- **Enhanced Type System**: New interfaces for label operations with full TypeScript support
-  - `TodoistLabel`, `CreateLabelArgs`, `UpdateLabelArgs`, `LabelNameArgs`, `LabelStatistics`
-  - Runtime type validation with dedicated type guards for all label operations
-- **Label Validation**: Comprehensive input validation and sanitization
-  - Supports all Todoist color names and hex codes
-  - Label name length validation and trimming
-  - Order position validation for label organization
-- **Caching Integration**: Label operations use intelligent caching for optimal performance
-  - 30-second TTL for label data with automatic cache invalidation
-  - Separate cache management for label statistics
-
-### Changed
-- **Tool Count**: Increased from 18 to 23 total MCP tools
-- **Test Coverage**: Updated `todoist_test_all_features` to include comprehensive label testing
-- **Error Handling**: Added `LabelNotFoundError` for specific label operation failures
-
-### Enhanced
-- **Performance**: Label operations leverage existing caching infrastructure
-- **Documentation**: Updated README.md with label management examples and usage patterns
 
 ## [0.6.0] - 2024-12-06
 
 ### Added
 - **Testing Infrastructure**: Comprehensive testing system with 3 new MCP tools
-  - `todoist_test_connection` - Quick API token validation and connection test
-  - `todoist_test_all_features` - Comprehensive testing of all MCP tools and API operations
-  - `todoist_test_performance` - Performance benchmarking with configurable iterations
-- **Integration Test Suite**: Full API integration testing in `src/__tests__/integration.test.ts`
-  - Graceful handling when `TODOIST_API_TOKEN` environment variable is not available
-  - Comprehensive testing of tasks, projects, labels, sections, and comments
-  - Performance validation and error handling tests
-- **API Response Handling**: Robust support for multiple Todoist API response formats
-  - Added `extractArrayFromResponse()` helper function for defensive API parsing
-  - Handles direct arrays, `result.results`, and `result.data` response patterns
-- **Development Documentation**: Added comprehensive development PRD (`todoist-mcp-dev-prd.md`)
-  - Detailed roadmap for future phases (label management, subtask handling, duplicate detection, analytics)
-  - Implementation guides and architectural patterns
-
-### Changed
-- **Enhanced Type Safety**: Replaced `any` types with proper TypeScript interfaces
-- **Code Quality**: Improved linting compliance and formatting consistency
-- **Tool Count**: Updated from 15 to 18 total MCP tools
-
-### Fixed
-- **API Compatibility**: Fixed handling of evolving Todoist API response formats
-- **Test Infrastructure**: Resolved issues with API response parsing in test functions
-- **Linting Errors**: Fixed all ESLint and Prettier formatting issues
-
-### Developer Experience
-- **Testing**: Run `TODOIST_API_TOKEN=your-token npm test` for full integration testing
-- **Validation**: Use `todoist_test_all_features` tool to verify functionality after changes
-- **Documentation**: Updated CLAUDE.md with comprehensive testing guidance
+- **Integration Test Suite**: Full API integration testing
 
 ## [0.5.3] - 2024-11-XX
 
@@ -444,86 +183,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2024-11-XX
 
 ### Fixed
-- **Deadline Parameter**: Changed `deadline` to `deadline_date` parameter (YYYY-MM-DD format) for proper Todoist API compatibility
-- **Deadline Display**: Task retrieval now properly displays deadline information alongside due dates
-
-### Changed
-- **Documentation**: Updated CLAUDE.md with clarification on due dates vs deadlines
-  - `due_string`/`due_date`: When the task appears in "Today" (start date)
-  - `deadline_date`: Actual deadline for task completion (YYYY-MM-DD format)
+- **Deadline Parameter**: Changed `deadline` to `deadline_date` parameter (YYYY-MM-DD format)
 
 ## [0.5.0] - 2024-11-XX
 
 ### Added
 - **Bulk Operations**: 4 new bulk tools for efficient multi-task operations
-  - `todoist_tasks_bulk_create` - Create multiple tasks at once
-  - `todoist_tasks_bulk_update` - Update multiple tasks based on search criteria
-  - `todoist_tasks_bulk_delete` - Delete multiple tasks based on search criteria
-  - `todoist_tasks_bulk_complete` - Complete multiple tasks based on search criteria
 - **Comment System**: Full comment support with file attachments
-  - `todoist_comment_create` - Add comments to tasks with optional file attachments
-  - `todoist_comment_get` - Retrieve comments for tasks or projects
-- **Enhanced Search**: Flexible search criteria for bulk operations
-  - Filter by project, priority, date ranges, and content matching
-
-### Changed
-- **Documentation**: Updated README with comprehensive examples for all new features
-- **Performance**: Improved efficiency for multi-task operations
 
 ## [0.4.0] - 2024-10-XX
 
 ### Added
 - **Modular Architecture**: Refactored monolithic code into focused modules
-- **Performance Optimization**: 30-second caching for GET operations to reduce API calls
-- **Robust Error Handling**: Custom error types with structured error responses
-- **Input Validation**: Comprehensive validation and sanitization of all inputs
-- **Code Quality**: ESLint, Prettier, and Jest testing framework integration
-- **Type Safety**: Full TypeScript implementation with runtime type checking
-
-### Changed
-- **Architecture**: Organized codebase into domain-specific handlers
-  - `src/handlers/task-handlers.ts` - Task CRUD operations
-  - `src/handlers/project-handlers.ts` - Project and section operations
-  - `src/handlers/comment-handlers.ts` - Comment operations
-- **Error Management**: Eliminated all `any` types for better type safety
+- **Performance Optimization**: 30-second caching for GET operations
 
 ## [0.3.0] - 2024-10-XX
 
 ### Added
 - **Complete Project Management**: Project and section creation tools
-  - `todoist_project_create` - Create new projects with color and favorite options
-  - `todoist_section_create` - Create sections within projects
-- **Enhanced Organization**: Full support for `project_id` and `section_id` in task operations
-- **Discovery Tools**: List projects and sections for ID discovery
-  - `todoist_project_get` - List all projects with IDs and names
-  - `todoist_section_get` - List sections within projects
-
-### Changed
-- **Tool Names**: Cleaner naming convention with proper MCP compliance (e.g., "Todoist Task Create")
-- **Organization**: Better support for hierarchical task organization
 
 ## [0.2.0] - 2024-09-XX
 
 ### Added
 - **Enhanced Task Creation**: Support for labels and deadline parameters
-- **Label Support**: Assign multiple labels to tasks during creation
-- **Deadline Management**: Set actual deadlines separate from due dates
-
-### Changed
-- **API Compliance**: Better alignment with Todoist API v2 specification
-- **Parameter Handling**: Improved handling of optional task attributes
 
 ## [0.1.0] - 2024-09-XX
 
 ### Added
 - **Initial Release**: Basic Todoist MCP server functionality
 - **Core Task Management**: Create, read, update, delete, and complete tasks
-- **Natural Language Interface**: Task search and filtering using everyday language
-- **Task Attributes**: Support for descriptions, due dates, and priority levels
-- **MCP Integration**: Full Model Context Protocol compliance for Claude Desktop
-
-### Features
-- 5 core task management tools
-- Natural language task identification
-- Basic error handling and validation
-- TypeScript implementation with proper types

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ An MCP (Model Context Protocol) server that connects Claude with Todoist for com
 * **Complete Task Management**: Create, read, update, delete, and complete tasks with full attribute support
 * **Hierarchical Subtasks**: Create subtasks, convert tasks to subtasks, promote subtasks, and view task hierarchies with completion tracking
 * **Bulk Operations**: Efficiently create, update, delete, or complete multiple tasks at once
-* **Full Comment Management**: Complete CRUD operations for task and project comments with attachment support
+* **Comment System**: Add comments to tasks and retrieve comments with attachment support
 * **Label Management**: Full CRUD operations for labels with usage statistics and analytics
+* **Reminder Management**: Create, update, and delete reminders (relative, absolute, location-based) via Sync API
 * **Project & Section Organization**: Create and manage projects and sections
 * **Dry-Run Mode**: Test automations and operations without making real changes
 * **Enhanced Testing**: Basic API validation and comprehensive CRUD testing with automatic cleanup
@@ -215,6 +216,7 @@ All 32 MCP tools support dry-run mode:
 - Bulk operations across multiple tasks
 - Project and section creation
 - Label management operations
+- Reminder CRUD operations
 - Comment creation
 
 ### Disabling Dry-Run Mode
@@ -223,7 +225,7 @@ Remove the `DRYRUN` environment variable or set it to `false`, then restart Clau
 
 ## Tools Overview
 
-The server provides 32 tools organized by entity type:
+The server provides 34 tools organized by entity type:
 
 ### Task Management
 - **Todoist Task Create**: Create new tasks with full attribute support
@@ -246,10 +248,8 @@ The server provides 32 tools organized by entity type:
 - **Todoist Tasks Bulk Complete**: Complete multiple tasks based on search criteria with timezone-aware due comparisons
 
 ### Comment Management
-- **Todoist Comment Create**: Add comments to tasks or projects with optional file attachments
+- **Todoist Comment Create**: Add comments to tasks with optional file attachments
 - **Todoist Comment Get**: Retrieve comments for tasks or projects
-- **Todoist Comment Update**: Update existing comment content by ID
-- **Todoist Comment Delete**: Delete comments by ID
 
 ### Label Management
 - **Todoist Label Get**: List all labels with their IDs and colors
@@ -267,6 +267,12 @@ The server provides 32 tools organized by entity type:
 - **Todoist Section Get**: List sections within projects
 - **Todoist Section Update**: Update section names (by ID or partial name search)
 - **Todoist Section Delete**: Delete sections and all contained tasks (by ID or partial name search)
+
+### Reminder Management (Requires Pro/Business)
+- **Todoist Reminder Get**: List all reminders, optionally filtered by task
+- **Todoist Reminder Create**: Create reminders (relative, absolute, or location-based)
+- **Todoist Reminder Update**: Update existing reminder settings
+- **Todoist Reminder Delete**: Remove reminders from tasks
 
 ### Testing & Validation
 - **Todoist Test Connection**: Validate API token and test connectivity
@@ -340,9 +346,6 @@ The server provides 32 tools organized by entity type:
 "Add comment with attachment to task 67890"
 "Show all comments for task 'Team Meeting'"
 "Get comments for project 12345"
-"Update comment 123456 to say 'Updated status: Ready for review'"
-"Delete comment 123456"
-"Add a project-level comment to project 12345"
 ```
 
 ### Label Management
@@ -352,6 +355,16 @@ The server provides 32 tools organized by entity type:
 "Update the 'Work' label to be blue and mark as favorite"
 "Delete the unused 'Old Project' label"
 "Get usage statistics for all my labels"
+```
+
+### Reminder Management (Pro/Business)
+```
+"Show me all my reminders"
+"Get reminders for task 'Team Meeting'"
+"Create a reminder for task 'Review PR' 30 minutes before due"
+"Create an absolute reminder for task 12345 at 2024-12-25T09:00:00Z"
+"Update reminder 67890 to trigger at 10:00 instead"
+"Delete reminder 67890"
 ```
 
 ### Task Discovery
@@ -482,6 +495,7 @@ The codebase follows a clean, modular architecture designed for maintainability 
   - `project-tools.ts` - Project/section management (4 tools)
   - `comment-tools.ts` - Comment operations (2 tools)
   - `label-tools.ts` - Label management (5 tools)
+  - `reminder-tools.ts` - Reminder operations (4 tools)
   - `test-tools.ts` - Testing and validation (3 tools)
   - `index.ts` - Centralized exports
 
@@ -492,6 +506,7 @@ The codebase follows a clean, modular architecture designed for maintainability 
   - `project-handlers.ts` - Project and section operations
   - `comment-handlers.ts` - Comment creation and retrieval
   - `label-handlers.ts` - Label CRUD and statistics
+  - `reminder-handlers.ts` - Reminder CRUD via Sync API
   - `test-handlers.ts` - API testing infrastructure
   - `test-handlers-enhanced/` - Comprehensive CRUD testing framework
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@greirson/mcp-todoist",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@greirson/mcp-todoist",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greirson/mcp-todoist",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP server for Todoist API",
   "main": "dist/index.js",
   "module": "./src/index.ts",

--- a/src/handlers/reminder-handlers.ts
+++ b/src/handlers/reminder-handlers.ts
@@ -1,0 +1,452 @@
+// Reminder handlers using Todoist Sync API
+// The REST API doesn't support reminders, so we use the Sync API directly
+
+import { TodoistApi } from "@doist/todoist-api-typescript";
+import {
+  TodoistReminder,
+  GetRemindersArgs,
+  CreateReminderArgs,
+  UpdateReminderArgs,
+  DeleteReminderArgs,
+  SyncResponse,
+} from "../types.js";
+import {
+  ValidationError,
+  TaskNotFoundError,
+  TodoistAPIError,
+} from "../errors.js";
+import { SimpleCache } from "../cache.js";
+
+// Cache for reminder data (30 second TTL)
+const reminderCache = new SimpleCache<TodoistReminder[]>(30000);
+
+// Todoist Sync API base URL
+const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+
+/**
+ * Get the API token from the TodoistApi client
+ * We need this for direct Sync API calls
+ */
+function getApiToken(): string {
+  const token = process.env.TODOIST_API_TOKEN;
+  if (!token) {
+    throw new TodoistAPIError("TODOIST_API_TOKEN not configured");
+  }
+  return token;
+}
+
+/**
+ * Make a Sync API request
+ */
+async function syncRequest(
+  endpoint: string,
+  body: Record<string, unknown>
+): Promise<SyncResponse> {
+  const token = getApiToken();
+
+  const response = await fetch(`${SYNC_API_URL}${endpoint}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(
+      Object.entries(body).map(([k, v]) => [
+        k,
+        typeof v === "string" ? v : JSON.stringify(v),
+      ])
+    ),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new TodoistAPIError(
+      `Sync API error (${response.status}): ${errorText}`
+    );
+  }
+
+  return (await response.json()) as SyncResponse;
+}
+
+/**
+ * Generate a UUID for Sync API commands
+ */
+function generateUUID(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Fetch all reminders from Sync API
+ */
+async function fetchReminders(): Promise<TodoistReminder[]> {
+  const cacheKey = "reminders:all";
+  const cached = reminderCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const response = await syncRequest("/sync", {
+    sync_token: "*",
+    resource_types: JSON.stringify(["reminders"]),
+  });
+
+  const reminders = (response.reminders || []).filter((r) => !r.is_deleted);
+  reminderCache.set(cacheKey, reminders);
+
+  return reminders;
+}
+
+/**
+ * Find a task by name or ID
+ */
+async function findTask(
+  todoistClient: TodoistApi,
+  taskId?: string,
+  taskName?: string
+): Promise<{ id: string; content: string }> {
+  if (taskId) {
+    try {
+      const task = await todoistClient.getTask(taskId);
+      return { id: task.id, content: task.content };
+    } catch {
+      throw new TaskNotFoundError(`Task with ID ${taskId} not found`);
+    }
+  }
+
+  if (!taskName) {
+    throw new ValidationError("Either task_id or task_name must be provided");
+  }
+
+  const tasks = await todoistClient.getTasks();
+  const taskArray = Array.isArray(tasks) ? tasks : [];
+  const matchingTask = taskArray.find((t) =>
+    t.content.toLowerCase().includes(taskName.toLowerCase())
+  );
+
+  if (!matchingTask) {
+    throw new TaskNotFoundError(`No task found matching "${taskName}"`);
+  }
+
+  return { id: matchingTask.id, content: matchingTask.content };
+}
+
+/**
+ * Format a reminder for display
+ */
+function formatReminder(reminder: TodoistReminder): string {
+  let details = `ID: ${reminder.id}, Type: ${reminder.type}`;
+
+  if (reminder.type === "relative" && reminder.minute_offset !== undefined) {
+    details += `, ${reminder.minute_offset} minutes before due`;
+  } else if (reminder.type === "absolute" && reminder.due) {
+    details += `, At: ${reminder.due.date}`;
+    if (reminder.due.timezone) {
+      details += ` (${reminder.due.timezone})`;
+    }
+  } else if (reminder.type === "location") {
+    details += `, Location: ${reminder.name || "unnamed"}`;
+    if (reminder.loc_lat && reminder.loc_long) {
+      details += ` (${reminder.loc_lat}, ${reminder.loc_long})`;
+    }
+    if (reminder.loc_trigger) {
+      details += `, Trigger: ${reminder.loc_trigger}`;
+    }
+    if (reminder.radius) {
+      details += `, Radius: ${reminder.radius}m`;
+    }
+  }
+
+  return details;
+}
+
+/**
+ * Handle getting reminders
+ */
+export async function handleGetReminders(
+  todoistClient: TodoistApi,
+  args: GetRemindersArgs
+): Promise<string> {
+  let reminders = await fetchReminders();
+
+  // Filter by task if specified
+  if (args.task_id || args.task_name) {
+    const task = await findTask(todoistClient, args.task_id, args.task_name);
+    reminders = reminders.filter((r) => r.item_id === task.id);
+
+    if (reminders.length === 0) {
+      return `No reminders found for task "${task.content}"`;
+    }
+
+    const reminderList = reminders
+      .map((r) => `  - ${formatReminder(r)}`)
+      .join("\n");
+    return `Found ${reminders.length} reminder(s) for task "${task.content}":\n${reminderList}`;
+  }
+
+  if (reminders.length === 0) {
+    return "No reminders found. Note: Reminders require Todoist Pro or Business plan.";
+  }
+
+  // Group reminders by task
+  const remindersByTask = new Map<string, TodoistReminder[]>();
+  for (const reminder of reminders) {
+    const taskReminders = remindersByTask.get(reminder.item_id) || [];
+    taskReminders.push(reminder);
+    remindersByTask.set(reminder.item_id, taskReminders);
+  }
+
+  let output = `Found ${reminders.length} reminder(s) across ${remindersByTask.size} task(s):\n\n`;
+
+  for (const [taskId, taskReminders] of remindersByTask) {
+    output += `Task ID: ${taskId}\n`;
+    for (const reminder of taskReminders) {
+      output += `  - ${formatReminder(reminder)}\n`;
+    }
+    output += "\n";
+  }
+
+  return output.trim();
+}
+
+/**
+ * Handle creating a reminder
+ */
+export async function handleCreateReminder(
+  todoistClient: TodoistApi,
+  args: CreateReminderArgs
+): Promise<string> {
+  // Validate and find the task
+  const task = await findTask(todoistClient, args.task_id, args.task_name);
+
+  // Validate reminder type-specific requirements
+  if (args.type === "relative") {
+    if (args.minute_offset === undefined) {
+      throw new ValidationError(
+        "minute_offset is required for relative reminders"
+      );
+    }
+    if (args.minute_offset < 0) {
+      throw new ValidationError("minute_offset must be a positive number");
+    }
+  } else if (args.type === "absolute") {
+    if (!args.due_date) {
+      throw new ValidationError("due_date is required for absolute reminders");
+    }
+  } else if (args.type === "location") {
+    if (!args.latitude || !args.longitude) {
+      throw new ValidationError(
+        "latitude and longitude are required for location reminders"
+      );
+    }
+    if (!args.location_trigger) {
+      throw new ValidationError(
+        "location_trigger (on_enter or on_leave) is required for location reminders"
+      );
+    }
+  }
+
+  // Build the command arguments
+  const commandArgs: Record<string, unknown> = {
+    item_id: task.id,
+    type: args.type,
+  };
+
+  if (args.type === "relative") {
+    commandArgs.minute_offset = args.minute_offset;
+  } else if (args.type === "absolute") {
+    commandArgs.due = {
+      date: args.due_date,
+      ...(args.timezone && { timezone: args.timezone }),
+    };
+  } else if (args.type === "location") {
+    commandArgs.name = args.location_name || "Location reminder";
+    commandArgs.loc_lat = args.latitude;
+    commandArgs.loc_long = args.longitude;
+    commandArgs.loc_trigger = args.location_trigger;
+    if (args.radius) {
+      commandArgs.radius = args.radius;
+    }
+  }
+
+  const tempId = generateUUID();
+  const uuid = generateUUID();
+
+  const response = await syncRequest("/sync", {
+    commands: JSON.stringify([
+      {
+        type: "reminder_add",
+        temp_id: tempId,
+        uuid: uuid,
+        args: commandArgs,
+      },
+    ]),
+  });
+
+  // Check for errors
+  if (response.sync_status[uuid] !== "ok") {
+    const status = response.sync_status[uuid];
+    if (typeof status === "object" && status !== null) {
+      throw new TodoistAPIError(
+        `Failed to create reminder: ${JSON.stringify(status)}`
+      );
+    }
+    throw new TodoistAPIError(`Failed to create reminder: ${status}`);
+  }
+
+  // Clear cache
+  reminderCache.clear();
+
+  const reminderId = response.temp_id_mapping?.[tempId] || "unknown";
+
+  let successMessage = `Created ${args.type} reminder (ID: ${reminderId}) for task "${task.content}"`;
+
+  if (args.type === "relative") {
+    successMessage += ` - ${args.minute_offset} minutes before due`;
+  } else if (args.type === "absolute") {
+    successMessage += ` - at ${args.due_date}`;
+  } else if (args.type === "location") {
+    successMessage += ` - at ${args.location_name || "location"} (${args.location_trigger})`;
+  }
+
+  return successMessage;
+}
+
+/**
+ * Handle updating a reminder
+ */
+export async function handleUpdateReminder(
+  args: UpdateReminderArgs
+): Promise<string> {
+  if (!args.reminder_id) {
+    throw new ValidationError("reminder_id is required");
+  }
+
+  // Build the update arguments
+  const commandArgs: Record<string, unknown> = {
+    id: args.reminder_id,
+  };
+
+  if (args.type) {
+    commandArgs.type = args.type;
+  }
+
+  if (args.minute_offset !== undefined) {
+    commandArgs.minute_offset = args.minute_offset;
+  }
+
+  if (args.due_date) {
+    commandArgs.due = {
+      date: args.due_date,
+      ...(args.timezone && { timezone: args.timezone }),
+    };
+  }
+
+  if (args.location_name) {
+    commandArgs.name = args.location_name;
+  }
+
+  if (args.latitude) {
+    commandArgs.loc_lat = args.latitude;
+  }
+
+  if (args.longitude) {
+    commandArgs.loc_long = args.longitude;
+  }
+
+  if (args.location_trigger) {
+    commandArgs.loc_trigger = args.location_trigger;
+  }
+
+  if (args.radius !== undefined) {
+    commandArgs.radius = args.radius;
+  }
+
+  const uuid = generateUUID();
+
+  const response = await syncRequest("/sync", {
+    commands: JSON.stringify([
+      {
+        type: "reminder_update",
+        uuid: uuid,
+        args: commandArgs,
+      },
+    ]),
+  });
+
+  // Check for errors
+  if (response.sync_status[uuid] !== "ok") {
+    const status = response.sync_status[uuid];
+    if (typeof status === "object" && status !== null) {
+      throw new TodoistAPIError(
+        `Failed to update reminder: ${JSON.stringify(status)}`
+      );
+    }
+    throw new TodoistAPIError(`Failed to update reminder: ${status}`);
+  }
+
+  // Clear cache
+  reminderCache.clear();
+
+  const changes: string[] = [];
+  if (args.type) changes.push(`type: ${args.type}`);
+  if (args.minute_offset !== undefined)
+    changes.push(`minute_offset: ${args.minute_offset}`);
+  if (args.due_date) changes.push(`due_date: ${args.due_date}`);
+  if (args.location_name) changes.push(`location: ${args.location_name}`);
+  if (args.location_trigger) changes.push(`trigger: ${args.location_trigger}`);
+
+  return `Updated reminder (ID: ${args.reminder_id})${changes.length > 0 ? ` - ${changes.join(", ")}` : ""}`;
+}
+
+/**
+ * Handle deleting a reminder
+ */
+export async function handleDeleteReminder(
+  args: DeleteReminderArgs
+): Promise<string> {
+  if (!args.reminder_id) {
+    throw new ValidationError("reminder_id is required");
+  }
+
+  const uuid = generateUUID();
+
+  const response = await syncRequest("/sync", {
+    commands: JSON.stringify([
+      {
+        type: "reminder_delete",
+        uuid: uuid,
+        args: {
+          id: args.reminder_id,
+        },
+      },
+    ]),
+  });
+
+  // Check for errors
+  if (response.sync_status[uuid] !== "ok") {
+    const status = response.sync_status[uuid];
+    if (typeof status === "object" && status !== null) {
+      throw new TodoistAPIError(
+        `Failed to delete reminder: ${JSON.stringify(status)}`
+      );
+    }
+    throw new TodoistAPIError(`Failed to delete reminder: ${status}`);
+  }
+
+  // Clear cache
+  reminderCache.clear();
+
+  return `Deleted reminder (ID: ${args.reminder_id})`;
+}
+
+/**
+ * Clear reminder cache (useful for testing)
+ */
+export function clearReminderCache(): void {
+  reminderCache.clear();
+}

--- a/src/handlers/test-handlers-enhanced/index.ts
+++ b/src/handlers/test-handlers-enhanced/index.ts
@@ -6,6 +6,7 @@ import { testLabelOperations } from "./label-tests.js";
 import { testBulkOperations } from "./bulk-tests.js";
 import { testSectionOperations } from "./section-tests.js";
 import { testCommentOperations } from "./comment-tests.js";
+import { testReminderOperations } from "./reminder-tests.js";
 import { TestSuite, ComprehensiveTestReport } from "./types.js";
 
 export async function handleTestAllFeaturesEnhanced(
@@ -21,6 +22,7 @@ export async function handleTestAllFeaturesEnhanced(
   suites.push(await testSectionOperations(todoistClient));
   suites.push(await testBulkOperations(todoistClient));
   suites.push(await testCommentOperations(todoistClient));
+  suites.push(await testReminderOperations(todoistClient));
 
   // Calculate totals
   const totalTests = suites.reduce((sum, suite) => sum + suite.tests.length, 0);
@@ -59,3 +61,4 @@ export { testLabelOperations } from "./label-tests.js";
 export { testSectionOperations } from "./section-tests.js";
 export { testBulkOperations } from "./bulk-tests.js";
 export { testCommentOperations } from "./comment-tests.js";
+export { testReminderOperations } from "./reminder-tests.js";

--- a/src/handlers/test-handlers-enhanced/reminder-tests.ts
+++ b/src/handlers/test-handlers-enhanced/reminder-tests.ts
@@ -1,0 +1,301 @@
+// Reminder operations testing module (Phase 10)
+import { TodoistApi } from "@doist/todoist-api-typescript";
+import {
+  handleGetReminders,
+  handleCreateReminder,
+  handleUpdateReminder,
+  handleDeleteReminder,
+} from "../reminder-handlers.js";
+import { TestSuite, EnhancedTestResult } from "./types.js";
+
+export async function testReminderOperations(
+  todoistClient: TodoistApi
+): Promise<TestSuite> {
+  const tests: EnhancedTestResult[] = [];
+  const startTime = Date.now();
+  let createdReminderId: string | null = null;
+  let testTaskId: string | null = null;
+  let testTaskContent: string | null = null;
+
+  // First, create a test task to attach reminders to
+  const taskSetupStart = Date.now();
+  try {
+    const timestamp = Date.now();
+    const testTask = await todoistClient.addTask({
+      content: `Test Reminder Task ${timestamp}`,
+      dueString: "tomorrow at 10am", // Task needs due date for relative reminders
+    });
+    testTaskId = testTask.id;
+    testTaskContent = testTask.content;
+
+    tests.push({
+      toolName: "setup_test_task",
+      operation: "SETUP",
+      status: "success",
+      message: "Created test task for reminder tests",
+      responseTime: Date.now() - taskSetupStart,
+      details: { taskId: testTaskId },
+    });
+  } catch (error) {
+    tests.push({
+      toolName: "setup_test_task",
+      operation: "SETUP",
+      status: "error",
+      message: "Failed to create test task for reminder tests",
+      responseTime: Date.now() - taskSetupStart,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+
+    // Return early if we can't create a test task
+    return {
+      suiteName: "Reminder Operations",
+      tests,
+      totalTime: Date.now() - startTime,
+      passed: 0,
+      failed: 1,
+      skipped: 4,
+    };
+  }
+
+  // Test 1: Get Reminders (initial - should be empty or existing)
+  const getStart = Date.now();
+  try {
+    const reminders = await handleGetReminders(todoistClient, {});
+    tests.push({
+      toolName: "todoist_reminder_get",
+      operation: "READ",
+      status: "success",
+      message: "Successfully retrieved reminders",
+      responseTime: Date.now() - getStart,
+      details: { resultLength: reminders.length },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    // Check if this is a plan limitation error
+    if (
+      errorMessage.includes("Pro") ||
+      errorMessage.includes("Business") ||
+      errorMessage.includes("premium")
+    ) {
+      tests.push({
+        toolName: "todoist_reminder_get",
+        operation: "READ",
+        status: "skipped",
+        message: "Skipped: Reminders require Todoist Pro or Business plan",
+        responseTime: Date.now() - getStart,
+      });
+
+      // Clean up test task and return early
+      if (testTaskId) {
+        try {
+          await todoistClient.deleteTask(testTaskId);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+
+      return {
+        suiteName: "Reminder Operations",
+        tests,
+        totalTime: Date.now() - startTime,
+        passed: 1, // Setup succeeded
+        failed: 0,
+        skipped: 4,
+      };
+    }
+
+    tests.push({
+      toolName: "todoist_reminder_get",
+      operation: "READ",
+      status: "error",
+      message: "Failed to retrieve reminders",
+      responseTime: Date.now() - getStart,
+      error: errorMessage,
+    });
+  }
+
+  // Test 2: Create Absolute Reminder
+  const createStart = Date.now();
+  try {
+    // Create a reminder for 1 hour from now
+    const reminderTime = new Date(Date.now() + 60 * 60 * 1000);
+    const createResult = await handleCreateReminder(todoistClient, {
+      task_id: testTaskId!,
+      type: "absolute",
+      due_date: reminderTime.toISOString(),
+    });
+
+    // Extract reminder ID from result
+    const idMatch = createResult.match(/ID: ([a-zA-Z0-9]+)/);
+    createdReminderId = idMatch ? idMatch[1] : null;
+
+    tests.push({
+      toolName: "todoist_reminder_create",
+      operation: "CREATE",
+      status: "success",
+      message: "Successfully created absolute reminder",
+      responseTime: Date.now() - createStart,
+      details: { reminderId: createdReminderId },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    if (
+      errorMessage.includes("Pro") ||
+      errorMessage.includes("Business") ||
+      errorMessage.includes("premium")
+    ) {
+      tests.push({
+        toolName: "todoist_reminder_create",
+        operation: "CREATE",
+        status: "skipped",
+        message: "Skipped: Reminders require Todoist Pro or Business plan",
+        responseTime: Date.now() - createStart,
+      });
+    } else {
+      tests.push({
+        toolName: "todoist_reminder_create",
+        operation: "CREATE",
+        status: "error",
+        message: "Failed to create reminder",
+        responseTime: Date.now() - createStart,
+        error: errorMessage,
+      });
+    }
+  }
+
+  // Test 3: Update Reminder
+  if (createdReminderId) {
+    const updateStart = Date.now();
+    try {
+      // Update to 2 hours from now
+      const newReminderTime = new Date(Date.now() + 2 * 60 * 60 * 1000);
+      await handleUpdateReminder({
+        reminder_id: createdReminderId,
+        due_date: newReminderTime.toISOString(),
+      });
+
+      tests.push({
+        toolName: "todoist_reminder_update",
+        operation: "UPDATE",
+        status: "success",
+        message: "Successfully updated reminder",
+        responseTime: Date.now() - updateStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "todoist_reminder_update",
+        operation: "UPDATE",
+        status: "error",
+        message: "Failed to update reminder",
+        responseTime: Date.now() - updateStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  } else {
+    tests.push({
+      toolName: "todoist_reminder_update",
+      operation: "UPDATE",
+      status: "skipped",
+      message: "Skipped: No reminder created to update",
+      responseTime: 0,
+    });
+  }
+
+  // Test 4: Get Reminders for Task
+  const getTaskRemindersStart = Date.now();
+  try {
+    const taskReminders = await handleGetReminders(todoistClient, {
+      task_id: testTaskId!,
+    });
+
+    tests.push({
+      toolName: "todoist_reminder_get",
+      operation: "READ",
+      status: "success",
+      message: "Successfully retrieved reminders for task",
+      responseTime: Date.now() - getTaskRemindersStart,
+      details: { resultLength: taskReminders.length },
+    });
+  } catch (error) {
+    tests.push({
+      toolName: "todoist_reminder_get",
+      operation: "READ",
+      status: "error",
+      message: "Failed to retrieve reminders for task",
+      responseTime: Date.now() - getTaskRemindersStart,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+
+  // Test 5: Delete Reminder
+  if (createdReminderId) {
+    const deleteStart = Date.now();
+    try {
+      await handleDeleteReminder({
+        reminder_id: createdReminderId,
+      });
+
+      tests.push({
+        toolName: "todoist_reminder_delete",
+        operation: "DELETE",
+        status: "success",
+        message: "Successfully deleted reminder",
+        responseTime: Date.now() - deleteStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "todoist_reminder_delete",
+        operation: "DELETE",
+        status: "error",
+        message: "Failed to delete reminder",
+        responseTime: Date.now() - deleteStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  } else {
+    tests.push({
+      toolName: "todoist_reminder_delete",
+      operation: "DELETE",
+      status: "skipped",
+      message: "Skipped: No reminder created to delete",
+      responseTime: 0,
+    });
+  }
+
+  // Cleanup: Delete the test task
+  if (testTaskId) {
+    const cleanupStart = Date.now();
+    try {
+      await todoistClient.deleteTask(testTaskId);
+      tests.push({
+        toolName: "cleanup_test_task",
+        operation: "CLEANUP",
+        status: "success",
+        message: `Cleaned up test task "${testTaskContent}"`,
+        responseTime: Date.now() - cleanupStart,
+      });
+    } catch (error) {
+      tests.push({
+        toolName: "cleanup_test_task",
+        operation: "CLEANUP",
+        status: "error",
+        message: "Failed to clean up test task",
+        responseTime: Date.now() - cleanupStart,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  const passed = tests.filter((t) => t.status === "success").length;
+  const failed = tests.filter((t) => t.status === "error").length;
+  const skipped = tests.filter((t) => t.status === "skipped").length;
+
+  return {
+    suiteName: "Reminder Operations",
+    tests,
+    totalTime: Date.now() - startTime,
+    passed,
+    failed,
+    skipped,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ import {
   isConvertToSubtaskArgs,
   isPromoteSubtaskArgs,
   isGetTaskHierarchyArgs,
+  isGetRemindersArgs,
+  isCreateReminderArgs,
+  isUpdateReminderArgs,
+  isDeleteReminderArgs,
 } from "./type-guards.js";
 import {
   handleCreateTask,
@@ -86,6 +90,12 @@ import {
   handlePromoteSubtask,
   handleGetTaskHierarchy,
 } from "./handlers/subtask-handlers.js";
+import {
+  handleGetReminders,
+  handleCreateReminder,
+  handleUpdateReminder,
+  handleDeleteReminder,
+} from "./handlers/reminder-handlers.js";
 import { handleError } from "./errors.js";
 import type { TaskHierarchy, TaskNode } from "./types.js";
 
@@ -116,7 +126,7 @@ function formatTaskHierarchy(hierarchy: TaskHierarchy): string {
 const server = new Server(
   {
     name: "todoist-mcp-server",
-    version: "0.9.0",
+    version: "0.10.0",
   },
   {
     capabilities: {
@@ -381,6 +391,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         const hierarchy = await handleGetTaskHierarchy(apiClient, args);
         result = formatTaskHierarchy(hierarchy);
+        break;
+
+      case "todoist_reminder_get":
+        if (!isGetRemindersArgs(args)) {
+          throw new Error("Invalid arguments for todoist_reminder_get");
+        }
+        result = await handleGetReminders(apiClient, args);
+        break;
+
+      case "todoist_reminder_create":
+        if (!isCreateReminderArgs(args)) {
+          throw new Error("Invalid arguments for todoist_reminder_create");
+        }
+        result = await handleCreateReminder(apiClient, args);
+        break;
+
+      case "todoist_reminder_update":
+        if (!isUpdateReminderArgs(args)) {
+          throw new Error("Invalid arguments for todoist_reminder_update");
+        }
+        result = await handleUpdateReminder(args);
+        break;
+
+      case "todoist_reminder_delete":
+        if (!isDeleteReminderArgs(args)) {
+          throw new Error("Invalid arguments for todoist_reminder_delete");
+        }
+        result = await handleDeleteReminder(args);
         break;
 
       case "todoist_test_connection":

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { SUBTASK_TOOLS } from "./subtask-tools.js";
 import { PROJECT_TOOLS } from "./project-tools.js";
 import { COMMENT_TOOLS } from "./comment-tools.js";
 import { LABEL_TOOLS } from "./label-tools.js";
+import { REMINDER_TOOLS } from "./reminder-tools.js";
 import { TEST_TOOLS } from "./test-tools.js";
 
 // Export individual tool categories
@@ -12,6 +13,7 @@ export { SUBTASK_TOOLS } from "./subtask-tools.js";
 export { PROJECT_TOOLS } from "./project-tools.js";
 export { COMMENT_TOOLS } from "./comment-tools.js";
 export { LABEL_TOOLS } from "./label-tools.js";
+export { REMINDER_TOOLS } from "./reminder-tools.js";
 export { TEST_TOOLS } from "./test-tools.js";
 
 // Export individual tools for backwards compatibility
@@ -60,6 +62,13 @@ export {
   TEST_PERFORMANCE_TOOL,
 } from "./test-tools.js";
 
+export {
+  GET_REMINDERS_TOOL,
+  CREATE_REMINDER_TOOL,
+  UPDATE_REMINDER_TOOL,
+  DELETE_REMINDER_TOOL,
+} from "./reminder-tools.js";
+
 // Combined array of all tools in the same order as the original
 export const ALL_TOOLS = [
   ...TASK_TOOLS,
@@ -67,5 +76,6 @@ export const ALL_TOOLS = [
   ...COMMENT_TOOLS,
   ...LABEL_TOOLS,
   ...SUBTASK_TOOLS,
+  ...REMINDER_TOOLS,
   ...TEST_TOOLS,
 ];

--- a/src/tools/reminder-tools.ts
+++ b/src/tools/reminder-tools.ts
@@ -1,0 +1,167 @@
+// Reminder management tools (Phase 10)
+// These tools use the Todoist Sync API for reminder CRUD operations
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const GET_REMINDERS_TOOL: Tool = {
+  name: "todoist_reminder_get",
+  description:
+    "Get all reminders, optionally filtered by task. Reminders require Todoist Pro or Business plan.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description:
+          "Filter reminders by task ID (optional - provide this OR task_name)",
+      },
+      task_name: {
+        type: "string",
+        description:
+          "Filter reminders by task name (optional - provide this OR task_id)",
+      },
+    },
+  },
+};
+
+export const CREATE_REMINDER_TOOL: Tool = {
+  name: "todoist_reminder_create",
+  description:
+    "Create a new reminder for a task. Supports three reminder types: relative (minutes before due), absolute (specific date/time), and location-based. Requires Todoist Pro or Business plan.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description:
+          "ID of the task to add reminder to (provide this OR task_name)",
+      },
+      task_name: {
+        type: "string",
+        description:
+          "Name of the task to add reminder to (provide this OR task_id)",
+      },
+      type: {
+        type: "string",
+        enum: ["relative", "absolute", "location"],
+        description:
+          "Type of reminder: 'relative' (minutes before due date), 'absolute' (specific date/time), or 'location' (geofenced)",
+      },
+      minute_offset: {
+        type: "number",
+        description:
+          "For relative reminders: minutes before the task due date to trigger (e.g., 30 for 30 minutes before)",
+      },
+      due_date: {
+        type: "string",
+        description:
+          "For absolute reminders: the date/time in ISO 8601 format (e.g., '2024-10-15T09:00:00Z')",
+      },
+      timezone: {
+        type: "string",
+        description:
+          "Timezone for absolute reminders (e.g., 'America/New_York')",
+      },
+      location_name: {
+        type: "string",
+        description: "For location reminders: alias name for the location",
+      },
+      latitude: {
+        type: "string",
+        description: "For location reminders: latitude coordinate",
+      },
+      longitude: {
+        type: "string",
+        description: "For location reminders: longitude coordinate",
+      },
+      location_trigger: {
+        type: "string",
+        enum: ["on_enter", "on_leave"],
+        description:
+          "For location reminders: when to trigger - 'on_enter' or 'on_leave'",
+      },
+      radius: {
+        type: "number",
+        description:
+          "For location reminders: radius around location in meters (default: 100)",
+      },
+    },
+    required: ["type"],
+  },
+};
+
+export const UPDATE_REMINDER_TOOL: Tool = {
+  name: "todoist_reminder_update",
+  description:
+    "Update an existing reminder. Can change the type, timing, or location settings. Requires Todoist Pro or Business plan.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      reminder_id: {
+        type: "string",
+        description: "ID of the reminder to update",
+      },
+      type: {
+        type: "string",
+        enum: ["relative", "absolute", "location"],
+        description: "New type of reminder (optional)",
+      },
+      minute_offset: {
+        type: "number",
+        description:
+          "For relative reminders: new minutes before the task due date",
+      },
+      due_date: {
+        type: "string",
+        description: "For absolute reminders: new date/time in ISO 8601 format",
+      },
+      timezone: {
+        type: "string",
+        description: "New timezone for absolute reminders",
+      },
+      location_name: {
+        type: "string",
+        description: "For location reminders: new alias name",
+      },
+      latitude: {
+        type: "string",
+        description: "For location reminders: new latitude",
+      },
+      longitude: {
+        type: "string",
+        description: "For location reminders: new longitude",
+      },
+      location_trigger: {
+        type: "string",
+        enum: ["on_enter", "on_leave"],
+        description: "For location reminders: new trigger condition",
+      },
+      radius: {
+        type: "number",
+        description: "For location reminders: new radius in meters",
+      },
+    },
+    required: ["reminder_id"],
+  },
+};
+
+export const DELETE_REMINDER_TOOL: Tool = {
+  name: "todoist_reminder_delete",
+  description: "Delete a reminder. Requires Todoist Pro or Business plan.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      reminder_id: {
+        type: "string",
+        description: "ID of the reminder to delete",
+      },
+    },
+    required: ["reminder_id"],
+  },
+};
+
+export const REMINDER_TOOLS = [
+  GET_REMINDERS_TOOL,
+  CREATE_REMINDER_TOOL,
+  UPDATE_REMINDER_TOOL,
+  DELETE_REMINDER_TOOL,
+];

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -23,6 +23,10 @@ import {
   ConvertToSubtaskArgs,
   PromoteSubtaskArgs,
   GetTaskHierarchyArgs,
+  GetRemindersArgs,
+  CreateReminderArgs,
+  UpdateReminderArgs,
+  DeleteReminderArgs,
 } from "./types.js";
 
 export function isCreateTaskArgs(args: unknown): args is CreateTaskArgs {
@@ -417,4 +421,87 @@ export function isGetTaskHierarchyArgs(
     (obj.include_completed === undefined ||
       typeof obj.include_completed === "boolean")
   );
+}
+
+// Reminder type guards (Phase 10)
+
+const VALID_REMINDER_TYPES = ["relative", "absolute", "location"];
+const VALID_LOCATION_TRIGGERS = ["on_enter", "on_leave"];
+
+export function isGetRemindersArgs(args: unknown): args is GetRemindersArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+  return (
+    (obj.task_id === undefined || typeof obj.task_id === "string") &&
+    (obj.task_name === undefined || typeof obj.task_name === "string")
+  );
+}
+
+export function isCreateReminderArgs(args: unknown): args is CreateReminderArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+
+  // Must have type
+  if (!("type" in obj) || typeof obj.type !== "string") {
+    return false;
+  }
+
+  // Validate type is one of the allowed values
+  if (!VALID_REMINDER_TYPES.includes(obj.type)) {
+    return false;
+  }
+
+  // Validate optional fields
+  return (
+    (obj.task_id === undefined || typeof obj.task_id === "string") &&
+    (obj.task_name === undefined || typeof obj.task_name === "string") &&
+    (obj.minute_offset === undefined || typeof obj.minute_offset === "number") &&
+    (obj.due_date === undefined || typeof obj.due_date === "string") &&
+    (obj.timezone === undefined || typeof obj.timezone === "string") &&
+    (obj.location_name === undefined || typeof obj.location_name === "string") &&
+    (obj.latitude === undefined || typeof obj.latitude === "string") &&
+    (obj.longitude === undefined || typeof obj.longitude === "string") &&
+    (obj.location_trigger === undefined ||
+      (typeof obj.location_trigger === "string" &&
+        VALID_LOCATION_TRIGGERS.includes(obj.location_trigger))) &&
+    (obj.radius === undefined || typeof obj.radius === "number")
+  );
+}
+
+export function isUpdateReminderArgs(args: unknown): args is UpdateReminderArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+
+  // Must have reminder_id
+  if (!("reminder_id" in obj) || typeof obj.reminder_id !== "string") {
+    return false;
+  }
+
+  // Validate optional fields
+  return (
+    (obj.type === undefined ||
+      (typeof obj.type === "string" && VALID_REMINDER_TYPES.includes(obj.type))) &&
+    (obj.minute_offset === undefined || typeof obj.minute_offset === "number") &&
+    (obj.due_date === undefined || typeof obj.due_date === "string") &&
+    (obj.timezone === undefined || typeof obj.timezone === "string") &&
+    (obj.location_name === undefined || typeof obj.location_name === "string") &&
+    (obj.latitude === undefined || typeof obj.latitude === "string") &&
+    (obj.longitude === undefined || typeof obj.longitude === "string") &&
+    (obj.location_trigger === undefined ||
+      (typeof obj.location_trigger === "string" &&
+        VALID_LOCATION_TRIGGERS.includes(obj.location_trigger))) &&
+    (obj.radius === undefined || typeof obj.radius === "number")
+  );
+}
+
+export function isDeleteReminderArgs(args: unknown): args is DeleteReminderArgs {
+  if (typeof args !== "object" || args === null) return false;
+
+  const obj = args as Record<string, unknown>;
+
+  // Must have reminder_id
+  return "reminder_id" in obj && typeof obj.reminder_id === "string";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,3 +396,127 @@ export interface TaskHierarchy {
   overallCompletion: number;
   originalTaskId?: string;
 }
+
+// Reminder operation interfaces (Phase 10: Reminder Management)
+// Based on Todoist Sync API v1
+
+/**
+ * Reminder types supported by Todoist
+ * - relative: Time-based reminder relative to task due date (uses minute_offset)
+ * - absolute: Time-based reminder at a specific date/time (uses due object)
+ * - location: Location-based reminder (uses location fields)
+ */
+export type ReminderType = "relative" | "absolute" | "location";
+
+/**
+ * Location trigger types for location-based reminders
+ */
+export type LocationTrigger = "on_enter" | "on_leave";
+
+/**
+ * Due date object for absolute reminders
+ */
+export interface ReminderDue {
+  date: string; // ISO 8601 format (e.g., "2024-10-15T11:00:00.000000Z")
+  timezone?: string;
+}
+
+/**
+ * Todoist Reminder object from the Sync API
+ */
+export interface TodoistReminder {
+  id: string;
+  notify_uid?: string;
+  item_id: string;
+  type: ReminderType;
+  due?: ReminderDue;
+  minute_offset?: number;
+  name?: string; // Location alias name
+  loc_lat?: string;
+  loc_long?: string;
+  loc_trigger?: LocationTrigger;
+  radius?: number;
+  is_deleted?: boolean;
+}
+
+/**
+ * Arguments for getting reminders
+ */
+export interface GetRemindersArgs {
+  task_id?: string;
+  task_name?: string;
+}
+
+/**
+ * Arguments for creating a reminder
+ */
+export interface CreateReminderArgs {
+  task_id?: string;
+  task_name?: string;
+  type: ReminderType;
+  // For relative reminders
+  minute_offset?: number;
+  // For absolute reminders
+  due_date?: string; // ISO 8601 format or natural language
+  timezone?: string;
+  // For location reminders
+  location_name?: string;
+  latitude?: string;
+  longitude?: string;
+  location_trigger?: LocationTrigger;
+  radius?: number;
+}
+
+/**
+ * Arguments for updating a reminder
+ */
+export interface UpdateReminderArgs {
+  reminder_id: string;
+  type?: ReminderType;
+  // For relative reminders
+  minute_offset?: number;
+  // For absolute reminders
+  due_date?: string;
+  timezone?: string;
+  // For location reminders
+  location_name?: string;
+  latitude?: string;
+  longitude?: string;
+  location_trigger?: LocationTrigger;
+  radius?: number;
+}
+
+/**
+ * Arguments for deleting a reminder
+ */
+export interface DeleteReminderArgs {
+  reminder_id: string;
+}
+
+/**
+ * Sync API command structure
+ */
+export interface SyncCommand {
+  type: string;
+  uuid: string;
+  temp_id?: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Sync API response structure
+ */
+export interface SyncResponse {
+  sync_status: Record<string, string>;
+  temp_id_mapping?: Record<string, string>;
+  reminders?: TodoistReminder[];
+  full_sync?: boolean;
+  sync_token?: string;
+}
+
+/**
+ * Response type for reminder operations
+ */
+export type RemindersResponse =
+  | TodoistReminder[]
+  | { reminders?: TodoistReminder[] };


### PR DESCRIPTION
## Summary
- Implements Phase 10: Reminder Management with full CRUD operations via Todoist Sync API
- Adds 4 new MCP tools for reminder operations (total: 34 tools)
- Integrates with Todoist Sync API v9 (REST API does not support reminders)

## New MCP Tools
- `todoist_reminder_get`: List all reminders, optionally filtered by task
- `todoist_reminder_create`: Create reminders (relative, absolute, location types)
- `todoist_reminder_update`: Update reminder timing and settings
- `todoist_reminder_delete`: Delete reminders by ID

## Technical Implementation
- Direct Sync API v9 integration with UUID-based command tracking
- Support for all three reminder types: relative, absolute, location
- Task resolution by both ID and name for attaching reminders
- Graceful handling of premium tier requirements (Pro/Business plans)
- 30-second TTL cache integration for reminder queries

## New Files
- `src/tools/reminder-tools.ts` - MCP tool definitions
- `src/handlers/reminder-handlers.ts` - Sync API integration
- `src/handlers/test-handlers-enhanced/reminder-tests.ts` - Test suite

## Version
Bumps version from 0.9.0 to 0.10.0

## Test plan
- [ ] Run `todoist_test_connection` to verify API connectivity
- [ ] Run `todoist_test_all_features` with `{ "mode": "enhanced" }` to test reminder CRUD
- [ ] Test creating relative reminders (minutes before due)
- [ ] Test creating absolute reminders (specific datetime)
- [ ] Verify graceful error handling for non-premium accounts