### PR TITLE
fix: remove incorrect client-side @label filtering for getTasksByFilter API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Remove incorrect client-side `@label` filtering when using `filter` parameter with `getTasksByFilter()` API -- complex filter queries like `(@labelA | @labelB) & today` were being mangled by naive regex extraction that didn't understand boolean logic (PR #69, thanks @dieend)
+
 ## [1.0.1] - 2026-01-26
 
 ### Fixed

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,9 +34,10 @@ export class TaskNotFoundError extends TodoistMCPError {
 export class ProjectNotFoundError extends TodoistMCPError {
   constructor(identifier: string) {
     // Check if it looks like an error message already
-    const message = identifier.includes("found") || identifier.includes("required")
-      ? identifier
-      : `Could not find project "${identifier}"`;
+    const message =
+      identifier.includes("found") || identifier.includes("required")
+        ? identifier
+        : `Could not find project "${identifier}"`;
     super(message, "PROJECT_NOT_FOUND", 404);
     this.name = "ProjectNotFoundError";
   }

--- a/src/handlers/test-handlers.ts
+++ b/src/handlers/test-handlers.ts
@@ -273,8 +273,9 @@ export async function handleTestAllFeatures(
 ): Promise<ComprehensiveTestResult | unknown> {
   // Use enhanced testing if requested
   if (args?.mode === "enhanced") {
-    const { handleTestAllFeaturesEnhanced } =
-      await import("./test-handlers-enhanced/index.js");
+    const { handleTestAllFeaturesEnhanced } = await import(
+      "./test-handlers-enhanced/index.js"
+    );
     return handleTestAllFeaturesEnhanced(todoistClient, apiToken);
   }
 


### PR DESCRIPTION
## Description
Problem:
When using the `filter` parameter with complex Todoist filter syntax like `!#work & (((@trigger_action) | (@tickler)) | @2-now)`, no tasks were returned even though matching tasks existed.

Root cause analysis:
In commit 05e3f5b (Issue #35), client-side @label filtering was added as a workaround for a bug in the Todoist TypeScript SDK where `getTasks()` ignored the label parameter. However, this filtering was incorrectly applied to BOTH:

1. `getTasks()` results - where the workaround was needed
2. `getTasksByFilter()` results - where it was NOT needed and caused bugs

The `getTasksByFilter()` API endpoint already correctly parses and evaluates complex filter syntax including labels, boolean operators (& |), and parentheses. The additional client-side filtering extracted ALL @label mentions from the filter string and required tasks to have ALL labels (when `&` appeared anywhere in the filter), completely ignoring the actual boolean logic.

For example, with filter `(@labelA | @labelB) & today`:
- API correctly returns: tasks with labelA OR labelB, due today
- Client-side bug required: tasks with BOTH labelA AND labelB

Fix:
Remove the client-side @label filtering when `getTasksByFilter()` is used, since the API handles filter parsing correctly. The `label_id` parameter workaround for `getTasks()` remains in place for that code path.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing completed
- [x] Tested with Claude Desktop

## Checklist
- [ ] Code follows the project's style guidelines
- [x] Self-review of code completed
- [ ] Code is commented where necessary
- [ ] Documentation updated if needed
- [ ] No breaking changes (or clearly documented)
- [ ] All CI checks pass

## Related Issues
Closes #(issue number)

## Additional Notes
Any additional information that reviewers should know.