### PR TITLE
fix: migrate deprecated Sync API v9 endpoints to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync API v9 Deprecation**: Migrated all deprecated `sync/v9` endpoints to the new `api/v1/sync` endpoint. The Todoist Sync API v9 now returns `410 Gone`, breaking `task_move`, `task_close`, `task_reorder`, and other sync-based operations. Updated 11 handler files and 7 test files. (PR #75, fixes #74)
 - Remove incorrect client-side `@label` filtering when using `filter` parameter with `getTasksByFilter()` API -- complex filter queries like `(@labelA | @labelB) & today` were being mangled by naive regex extraction that didn't understand boolean logic (PR #69, thanks @dieend)
 
 ## [1.0.1] - 2026-01-26
@@ -140,7 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Technical Implementation
 
-- **Sync API Integration**: Uses Todoist Sync API v9 endpoint `/sync/v9/completed/get_all`
+- **Sync API Integration**: Uses Todoist API v1 endpoint `/api/v1/completed/get_all`
 - **Quick Add API Integration**: Direct integration with `POST /api/v1/tasks/quick`
 - **Type Definitions**: Added `GetCompletedTasksArgs`, `CompletedTask`, `CompletedTasksResponse`, `QuickAddTaskArgs`, `QuickAddTaskResult`, `DurationUnit`, `TaskDuration`, `ReopenTaskArgs` interfaces
 - **Type Guards**: Added `isGetCompletedTasksArgs`, `isQuickAddTaskArgs`, and `isReopenTaskArgs` validation functions

--- a/src/__tests__/activity-handlers.test.ts
+++ b/src/__tests__/activity-handlers.test.ts
@@ -58,7 +58,7 @@ describe("Activity Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("https://api.todoist.com/sync/v9/activity/get"),
+        expect.stringContaining("https://api.todoist.com/api/v1/activity/get"),
         expect.objectContaining({
           method: "GET",
           headers: { Authorization: "Bearer test-token-123" },

--- a/src/__tests__/backup-handlers.test.ts
+++ b/src/__tests__/backup-handlers.test.ts
@@ -52,7 +52,7 @@ describe("Backup Handlers", () => {
       const result = await handleGetBackups();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9/backups/get",
+        "https://api.todoist.com/api/v1/backups/get",
         {
           method: "POST",
           headers: {

--- a/src/__tests__/collaboration-handlers.test.ts
+++ b/src/__tests__/collaboration-handlers.test.ts
@@ -57,7 +57,7 @@ describe("Collaboration Handlers", () => {
       expect(result).toContain("(default)");
       expect(result).toContain("Workspace 2");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({

--- a/src/__tests__/item-operations-handlers.test.ts
+++ b/src/__tests__/item-operations-handlers.test.ts
@@ -56,7 +56,7 @@ describe("Item Operations Handlers", () => {
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({

--- a/src/__tests__/project-notes-handlers.test.ts
+++ b/src/__tests__/project-notes-handlers.test.ts
@@ -60,7 +60,7 @@ describe("Project Notes Handlers", () => {
       expect(result).toContain("Test note content");
       expect(result).toContain("Another note");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
@@ -147,7 +147,7 @@ describe("Project Notes Handlers", () => {
       expect(result).toContain("Project note created successfully");
       expect(result).toContain("New note content");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
         })

--- a/src/__tests__/project-operations-handlers.test.ts
+++ b/src/__tests__/project-operations-handlers.test.ts
@@ -73,7 +73,7 @@ describe("Project Operations Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: {
@@ -317,7 +317,7 @@ describe("Project Operations Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: {

--- a/src/__tests__/user-handlers.test.ts
+++ b/src/__tests__/user-handlers.test.ts
@@ -67,7 +67,7 @@ describe("User Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: {
@@ -186,7 +186,7 @@ describe("User Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9/completed/get_stats",
+        "https://api.todoist.com/api/v1/completed/get_stats",
         expect.objectContaining({
           method: "POST",
           headers: {
@@ -274,7 +274,7 @@ describe("User Handlers", () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.todoist.com/sync/v9",
+        "https://api.todoist.com/api/v1/sync",
         expect.objectContaining({
           method: "POST",
           headers: {

--- a/src/handlers/activity-handlers.ts
+++ b/src/handlers/activity-handlers.ts
@@ -12,7 +12,7 @@ import { SimpleCache } from "../cache.js";
 const activityCache = new SimpleCache<ActivityResponse>(30000);
 
 // Base URL for Todoist Sync API
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1";
 
 /**
  * Get the API token from the environment

--- a/src/handlers/backup-handlers.ts
+++ b/src/handlers/backup-handlers.ts
@@ -2,7 +2,7 @@ import { TodoistBackup, DownloadBackupArgs } from "../types.js";
 import { TodoistAPIError, ValidationError } from "../errors.js";
 import { SimpleCache } from "../cache.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1";
 
 const backupsCache = new SimpleCache<TodoistBackup[]>(30000);
 

--- a/src/handlers/collaboration-handlers.ts
+++ b/src/handlers/collaboration-handlers.ts
@@ -14,7 +14,7 @@ import {
 import { TodoistAPIError, ValidationError } from "../errors.js";
 import { SimpleCache } from "../cache.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 const workspacesCache = new SimpleCache<Workspace[]>(30000);
 const invitationsCache = new SimpleCache<Invitation[]>(30000);

--- a/src/handlers/item-operations-handlers.ts
+++ b/src/handlers/item-operations-handlers.ts
@@ -17,7 +17,7 @@ import {
 } from "../errors.js";
 import { extractArrayFromResponse } from "../utils/api-helpers.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 function getApiToken(): string {
   const token = process.env.TODOIST_API_TOKEN;

--- a/src/handlers/project-notes-handlers.ts
+++ b/src/handlers/project-notes-handlers.ts
@@ -10,7 +10,7 @@ import {
 import { TodoistAPIError, ValidationError } from "../errors.js";
 import { SimpleCache } from "../cache.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 const projectNotesCache = new SimpleCache<ProjectNote[]>(30000);
 

--- a/src/handlers/project-operations-handlers.ts
+++ b/src/handlers/project-operations-handlers.ts
@@ -9,7 +9,7 @@ import {
 import { ValidationError, TodoistAPIError } from "../errors.js";
 import { extractArrayFromResponse } from "../utils/api-helpers.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 function getApiToken(): string {
   const token = process.env.TODOIST_API_TOKEN;

--- a/src/handlers/reminder-handlers.ts
+++ b/src/handlers/reminder-handlers.ts
@@ -21,7 +21,7 @@ import { SimpleCache } from "../cache.js";
 const reminderCache = new SimpleCache<TodoistReminder[]>(30000);
 
 // Todoist Sync API base URL
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 /**
  * Get the API token from the TodoistApi client

--- a/src/handlers/section-operations-handlers.ts
+++ b/src/handlers/section-operations-handlers.ts
@@ -10,7 +10,7 @@ import {
 import { ValidationError, TodoistAPIError } from "../errors.js";
 import { extractArrayFromResponse } from "../utils/api-helpers.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 function getApiToken(): string {
   const token = process.env.TODOIST_API_TOKEN;

--- a/src/handlers/shared-label-handlers.ts
+++ b/src/handlers/shared-label-handlers.ts
@@ -8,7 +8,7 @@ import {
 import { ValidationError, TodoistAPIError } from "../errors.js";
 import { SimpleCache } from "../cache.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 const sharedLabelsCache = new SimpleCache<SharedLabel[]>(30000);
 

--- a/src/handlers/task/completed.ts
+++ b/src/handlers/task/completed.ts
@@ -59,7 +59,7 @@ export async function handleGetCompletedTasks(
     }
 
     const queryString = params.toString();
-    const url = `https://api.todoist.com/sync/v9/completed/get_all${queryString ? `?${queryString}` : ""}`;
+    const url = `https://api.todoist.com/api/v1/completed/get_all${queryString ? `?${queryString}` : ""}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/src/handlers/user-handlers.ts
+++ b/src/handlers/user-handlers.ts
@@ -2,7 +2,7 @@ import { UserInfo, ProductivityStats, SyncApiResponse } from "../types.js";
 import { TodoistAPIError } from "../errors.js";
 import { SimpleCache } from "../cache.js";
 
-const SYNC_API_URL = "https://api.todoist.com/sync/v9";
+const SYNC_API_URL = "https://api.todoist.com/api/v1/sync";
 
 const userCache = new SimpleCache<UserInfo>(30000);
 const statsCache = new SimpleCache<ProductivityStats>(30000);
@@ -114,7 +114,7 @@ export async function handleGetProductivityStats(): Promise<string> {
   const token = getApiToken();
 
   const response = await fetch(
-    "https://api.todoist.com/sync/v9/completed/get_stats",
+    "https://api.todoist.com/api/v1/completed/get_stats",
     {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Summary

- Migrates all Todoist Sync API URLs from deprecated `sync/v9` to the new `api/v1/sync` endpoint
- Updates standalone endpoints (`activity/get`, `backups/get`, `completed/get_all`, `completed/get_stats`) to use `api/v1` base
- Updates all corresponding test files to match

The `sync/v9` endpoints now return `410 Gone`, breaking `task_move`, `task_close`, and other sync-based operations.

Fixes #74

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] Verified `task_move` works with the patched endpoints
- [x] Verified `task_complete` works with the patched endpoints
- [ ] Run full test suite (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)