### PR TITLE
fix: correct priority documentation across all tool schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Task created successfully (simulated):
 ID: 100001
 Title: Test Task
 Project: Work (2203306141)
-Priority: 4 (Normal)
+Priority: 4 (P4/Normal)
 ```
 
 ### Supported Operations
@@ -227,7 +227,7 @@ The Quick Add tool parses natural language text like the Todoist app, supporting
 - **Projects**: `#ProjectName` (no spaces in project names)
 - **Labels**: `@label` (e.g., "@urgent", "@work")
 - **Assignees**: `+name` (for shared projects)
-- **Priority**: `p1` (urgent), `p2`, `p3`, `p4` (lowest)
+- **Priority**: `p1` (urgent/highest), `p2` (high), `p3` (medium), `p4` (normal/lowest)
 - **Deadlines**: `{in 3 days}` or `{March 15}`
 - **Descriptions**: `//your description here` (must be at the end)
 

--- a/TOOLS_REFERENCE.md
+++ b/TOOLS_REFERENCE.md
@@ -58,7 +58,7 @@ Manage Todoist tasks - create, read, update, delete, complete, reopen, or quick 
 | `due_string`    | string | Due date in natural language (e.g., 'tomorrow', 'next Monday')                 |
 | `due_date`      | string | Due date in YYYY-MM-DD format                                                  |
 | `deadline_date` | string | Actual deadline in YYYY-MM-DD format                                           |
-| `priority`      | number | Priority 1 (highest) to 4 (lowest)                                             |
+| `priority`      | number | Priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal)                             |
 | `project_id`    | string | Project ID to assign task to                                                   |
 | `section_id`    | string | Section ID within project                                                      |
 | `labels`        | array  | Array of label names to assign                                                 |
@@ -101,7 +101,7 @@ Perform bulk operations on Todoist tasks - create, update, delete, or complete m
 | `tasks`            | array  | Array of task objects to create (for bulk_create)                          |
 | `search_criteria`  | object | Criteria to find tasks (for bulk_update)                                   |
 | `project_id`       | string | Filter by project ID                                                       |
-| `priority`         | number | Filter by priority 1-4                                                     |
+| `priority`         | number | Filter by priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal)              |
 | `due_before`       | string | Filter tasks due before date (YYYY-MM-DD)                                  |
 | `due_after`        | string | Filter tasks due after date (YYYY-MM-DD)                                   |
 | `content_contains` | string | Filter tasks containing text                                               |

--- a/src/tools/subtask-tools.ts
+++ b/src/tools/subtask-tools.ts
@@ -31,7 +31,7 @@ export const CREATE_SUBTASK_TOOL: Tool = {
       },
       priority: {
         type: "number",
-        description: "Priority level 1 (highest) to 4 (lowest)",
+        description: "Priority: 1=P1 (urgent) to 4=P4 (normal)",
         minimum: 1,
         maximum: 4,
       },
@@ -85,7 +85,7 @@ export const BULK_CREATE_SUBTASKS_TOOL: Tool = {
             },
             priority: {
               type: "number",
-              description: "Priority level 1 (highest) to 4 (lowest)",
+              description: "Priority: 1=P1 (urgent) to 4=P4 (normal)",
               minimum: 1,
               maximum: 4,
             },

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -23,7 +23,7 @@ export const CREATE_TASK_TOOL: Tool = {
       },
       priority: {
         type: "number",
-        description: "Task priority from 1 (highest) to 4 (lowest) (optional)",
+        description: "Priority level: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal) (optional)",
         enum: [1, 2, 3, 4],
       },
       labels: {
@@ -101,7 +101,7 @@ export const GET_TASKS_TOOL: Tool = {
       priority: {
         type: "number",
         description:
-          "Filter tasks by priority level 1 (highest) to 4 (lowest) (optional)",
+          "Filter tasks by priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal) (optional)",
         enum: [1, 2, 3, 4],
       },
       limit: {
@@ -170,7 +170,7 @@ export const UPDATE_TASK_TOOL: Tool = {
       },
       priority: {
         type: "number",
-        description: "New priority from 1 (normal) to 4 (urgent) (optional)",
+        description: "New priority from 1 (P1/urgent) to 4 (P4/normal) (optional)",
         enum: [1, 2, 3, 4],
       },
       labels: {
@@ -377,7 +377,7 @@ export const BULK_UPDATE_TASKS_TOOL: Tool = {
           priority: {
             type: "number",
             description:
-              "Filter tasks by priority level 1 (highest) to 4 (lowest) (optional)",
+              "Filter tasks by priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal) (optional)",
             enum: [1, 2, 3, 4],
           },
           due_before: {
@@ -468,7 +468,7 @@ export const BULK_DELETE_TASKS_TOOL: Tool = {
       priority: {
         type: "number",
         description:
-          "Delete tasks with this priority level 1 (highest) to 4 (lowest) (optional)",
+          "Delete tasks with priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal) (optional)",
         enum: [1, 2, 3, 4],
       },
       due_before: {
@@ -503,7 +503,7 @@ export const BULK_COMPLETE_TASKS_TOOL: Tool = {
       priority: {
         type: "number",
         description:
-          "Complete tasks with this priority level 1 (highest) to 4 (lowest) (optional)",
+          "Complete tasks with priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal) (optional)",
         enum: [1, 2, 3, 4],
       },
       due_before: {

--- a/src/tools/unified/task-unified.ts
+++ b/src/tools/unified/task-unified.ts
@@ -81,7 +81,7 @@ Due dates vs deadlines: due_string/due_date sets when task appears in "Today", d
       // Priority and organization
       priority: {
         type: "number",
-        description: "Priority 1 (highest/urgent) to 4 (lowest/normal)",
+        description: "Priority: 1=P1 (urgent), 2=P2, 3=P3, 4=P4 (normal)",
         enum: [1, 2, 3, 4],
       },
       project_id: {

--- a/src/utils/priority-mapper.ts
+++ b/src/utils/priority-mapper.ts
@@ -11,7 +11,13 @@ function isValidPriority(value: number | undefined): value is number {
 }
 
 /**
- * Converts user-facing priority (1 highest) to Todoist API priority (4 highest).
+ * Converts user-facing priority (1=P1 highest/urgent) to Todoist API priority (4=P1 highest/urgent).
+ *
+ * User Priority -> API Priority -> Todoist UI
+ * 1 (P1 urgent) -> 4 -> P1 (red flag)
+ * 2 (P2 high)   -> 3 -> P2 (orange flag)
+ * 3 (P3 medium) -> 2 -> P3 (yellow flag)
+ * 4 (P4 normal) -> 1 -> P4 (no flag)
  */
 export function toApiPriority(priority?: number): number | undefined {
   if (!isValidPriority(priority)) {
@@ -22,7 +28,13 @@ export function toApiPriority(priority?: number): number | undefined {
 }
 
 /**
- * Converts Todoist API priority (4 highest) to user-facing priority (1 highest).
+ * Converts Todoist API priority (4=P1 highest) to user-facing priority (1=P1 highest).
+ *
+ * API Priority -> User Priority -> Todoist UI
+ * 4 -> 1 (P1 urgent) -> P1 (red flag)
+ * 3 -> 2 (P2 high)   -> P2 (orange flag)
+ * 2 -> 3 (P3 medium) -> P3 (yellow flag)
+ * 1 -> 4 (P4 normal) -> P4 (no flag)
  */
 export function fromApiPriority(priority?: number | null): number | undefined {
   if (!isValidPriority(priority ?? undefined)) {


### PR DESCRIPTION
## Summary

- Fixed critical backwards priority description in `UPDATE_TASK_TOOL`: was "1 (normal) to 4 (urgent)", now correctly "1=P1 (urgent) to 4=P4 (normal)"
- Standardized all priority descriptions across tool schemas to use consistent P1/P2/P3/P4 labels
- Added detailed JSDoc mapping tables in `priority-mapper.ts`

**All priority descriptions now clearly state:**
- `priority: 1` = **P1** (urgent/highest)
- `priority: 2` = **P2** (high)
- `priority: 3` = **P3** (medium)
- `priority: 4` = **P4** (normal/lowest)

## Files Changed (6)

- `src/tools/task-tools.ts` — CREATE, GET, UPDATE, BULK tool schemas
- `src/tools/subtask-tools.ts` — CREATE_SUBTASK, BULK_CREATE_SUBTASKS
- `src/tools/unified/task-unified.ts` — unified task tool
- `src/utils/priority-mapper.ts` — JSDoc with mapping tables
- `README.md` — priority examples
- `TOOLS_REFERENCE.md` — priority column descriptions

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 422 tests pass (24 suites)
- [x] `npm run lint` — 0 errors
- [x] Diff contains ONLY priority documentation changes (no pagination, no API, no project names)

Extracted from #76 per review feedback — focused, zero-risk documentation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)