### PR TITLE
feat: resolve project names in task output

### DIFF
--- a/src/__tests__/task-handlers-update.test.ts
+++ b/src/__tests__/task-handlers-update.test.ts
@@ -77,10 +77,17 @@ describe("handleUpdateTask section moves", () => {
       },
     ] as unknown as ApiTaskList);
 
+    const getProjects = jest
+      .fn<TodoistApi["getProjects"]>()
+      .mockResolvedValue([
+        { id: "proj-new", name: "New Project" },
+      ] as unknown as ApiProjectsResponse);
+
     const todoistClient = {
       getTask,
       updateTask,
       moveTasks,
+      getProjects,
     } as unknown as TodoistApi;
 
     const message = await handleUpdateTask(todoistClient, {
@@ -95,7 +102,7 @@ describe("handleUpdateTask section moves", () => {
     expect(moveTasks).toHaveBeenCalledWith(["a1"], {
       projectId: "proj-new",
     });
-    expect(message).toContain("New Project ID: proj-new");
+    expect(message).toContain("New Project: New Project");
     expect(message).toContain("New Title: Updated");
   });
 });

--- a/src/handlers/task/completed.ts
+++ b/src/handlers/task/completed.ts
@@ -11,7 +11,10 @@ import {
   validateProjectId,
   VALIDATION_LIMITS,
 } from "../../validation/index.js";
-import { extractApiToken } from "../../utils/api-helpers.js";
+import {
+  extractApiToken,
+  resolveProjectNames,
+} from "../../utils/api-helpers.js";
 import { ErrorHandler } from "../../utils/error-handling.js";
 import { API_V1_BASE } from "../../utils/api-constants.js";
 
@@ -84,6 +87,15 @@ export async function handleGetCompletedTasks(
       return "No completed tasks found matching the criteria.";
     }
 
+    // Resolve project names in one batch call
+    const uniqueProjectIds = [
+      ...new Set(data.items.map((item) => item.project_id)),
+    ];
+    const projectNames = await resolveProjectNames(
+      todoistClient,
+      uniqueProjectIds
+    );
+
     const taskCount = data.items.length;
     const taskWord = taskCount === 1 ? "task" : "tasks";
 
@@ -91,9 +103,7 @@ export async function handleGetCompletedTasks(
 
     for (const item of data.items) {
       const projectName =
-        data.projects?.[item.project_id]?.name ||
-        item.project_id ||
-        "Unknown Project";
+        projectNames[item.project_id] || "Unknown Project";
       const completedDate = item.completed_at.split("T")[0];
 
       result += `- ${item.content}\n`;

--- a/src/handlers/task/crud.ts
+++ b/src/handlers/task/crud.ts
@@ -25,6 +25,7 @@ import {
   extractArrayFromResponse,
   createCacheKey,
   formatTaskForDisplay,
+  resolveProjectNames,
 } from "../../utils/api-helpers.js";
 import {
   formatDueDetails,
@@ -194,6 +195,23 @@ export async function handleCreateTask(
       ? `\nDuration: ${task.duration.amount} ${task.duration.unit}${task.duration.amount !== 1 ? "s" : ""}`
       : "";
 
+    // Resolve project name
+    let projectDisplay = args.project_id
+      ? `\nProject ID: ${args.project_id}`
+      : "";
+    if (task.projectId) {
+      try {
+        const names = await resolveProjectNames(todoistClient, [
+          task.projectId,
+        ]);
+        if (names[task.projectId]) {
+          projectDisplay = `\nProject: ${names[task.projectId]}`;
+        }
+      } catch {
+        // Fall back to ID display
+      }
+    }
+
     return `${prefix}Task created:\nID: ${task.id}\nTitle: ${task.content}${
       task.description ? `\nDescription: ${task.description}` : ""
     }${dueDetails ? `\nDue: ${dueDetails}` : ""}${
@@ -202,9 +220,7 @@ export async function handleCreateTask(
       task.labels && task.labels.length > 0
         ? `\nLabels: ${task.labels.join(", ")}`
         : ""
-    }${args.deadline_date ? `\nDeadline: ${args.deadline_date}` : ""}${
-      args.project_id ? `\nProject ID: ${args.project_id}` : ""
-    }${args.section_id ? `\nSection ID: ${args.section_id}` : ""}${durationDisplay}`;
+    }${args.deadline_date ? `\nDeadline: ${args.deadline_date}` : ""}${projectDisplay}${args.section_id ? `\nSection ID: ${args.section_id}` : ""}${durationDisplay}`;
   });
 }
 
@@ -228,8 +244,12 @@ export async function handleGetTasks(
   // If task_id is provided, fetch specific task
   if (args.task_id) {
     try {
-      const task = await todoistClient.getTask(args.task_id);
-      return formatTaskForDisplay(task as TodoistTask);
+      const task = (await todoistClient.getTask(args.task_id)) as TodoistTask;
+      const projectId = task.projectId || "";
+      const names = projectId
+        ? await resolveProjectNames(todoistClient, [projectId])
+        : {};
+      return formatTaskForDisplay(task, names[projectId]);
     } catch {
       return `Task with ID "${args.task_id}" not found`;
     }
@@ -369,8 +389,19 @@ export async function handleGetTasks(
     filteredTasks = filteredTasks.slice(0, args.limit);
   }
 
+  // Resolve project names for all tasks in one batch call
+  const projectIds = filteredTasks
+    .map((t) => t.projectId)
+    .filter(Boolean) as string[];
+  const projectNames = await resolveProjectNames(todoistClient, projectIds);
+
   const taskList = filteredTasks
-    .map((task) => formatTaskForDisplay(task))
+    .map((task) =>
+      formatTaskForDisplay(
+        task,
+        task.projectId ? projectNames[task.projectId] : undefined
+      )
+    )
     .join("\n\n");
 
   const taskCount = filteredTasks.length;
@@ -470,10 +501,17 @@ export async function handleUpdateTask(
 
   const displayUpdatedPriority = fromApiPriority(latestTask.priority);
   const updatedDueDetails = formatDueDetails(latestTask.due);
-  const projectLine =
-    requestedProjectId && latestTask.projectId
-      ? `\nNew Project ID: ${latestTask.projectId}`
-      : "";
+  let projectLine = "";
+  if (requestedProjectId && latestTask.projectId) {
+    try {
+      const names = await resolveProjectNames(todoistClient, [
+        latestTask.projectId,
+      ]);
+      projectLine = `\nNew Project: ${names[latestTask.projectId] || latestTask.projectId}`;
+    } catch {
+      projectLine = `\nNew Project ID: ${latestTask.projectId}`;
+    }
+  }
   const sectionLine = requestedSectionId
     ? `\nNew Section ID: ${latestTask.sectionId ?? "None"}`
     : "";

--- a/src/utils/api-helpers.ts
+++ b/src/utils/api-helpers.ts
@@ -109,18 +109,22 @@ export function createCacheKey(
  * @param task - The task object to format
  * @returns Formatted string representation of the task
  */
-export function formatTaskForDisplay(task: {
-  id?: string;
-  content: string;
-  description?: string;
-  due?: { string: string } | null;
-  deadline?: { date: string } | null;
-  priority?: number;
-  labels?: string[];
-  assigneeId?: string | null;
-  assignedByUid?: string | null;
-  responsibleUid?: string | null;
-}): string {
+export function formatTaskForDisplay(
+  task: {
+    id?: string;
+    content: string;
+    description?: string;
+    due?: { string: string } | null;
+    deadline?: { date: string } | null;
+    priority?: number;
+    labels?: string[];
+    projectId?: string;
+    assigneeId?: string | null;
+    assignedByUid?: string | null;
+    responsibleUid?: string | null;
+  },
+  projectName?: string
+): string {
   const displayPriority = fromApiPriority(task.priority);
   const dueDetails = formatDueDetails(
     task.due as TodoistTaskDueData | null | undefined
@@ -128,6 +132,11 @@ export function formatTaskForDisplay(task: {
   // Show assignment info (responsibleUid is the Todoist API field for assigned user)
   const assigneeDisplay = task.responsibleUid || task.assigneeId;
   const assignedByDisplay = task.assignedByUid;
+  const projectDisplay = projectName
+    ? `\n  Project: ${projectName}`
+    : task.projectId
+      ? `\n  Project ID: ${task.projectId}`
+      : "";
   return `- ${task.content}${task.id ? ` (ID: ${task.id})` : ""}${
     task.description ? `\n  Description: ${task.description}` : ""
   }${dueDetails ? `\n  Due: ${dueDetails}` : ""}${
@@ -136,9 +145,46 @@ export function formatTaskForDisplay(task: {
     task.labels && task.labels.length > 0
       ? `\n  Labels: ${task.labels.join(", ")}`
       : ""
-  }${assigneeDisplay ? `\n  Assigned To (User ID): ${assigneeDisplay}` : ""}${
+  }${projectDisplay}${assigneeDisplay ? `\n  Assigned To (User ID): ${assigneeDisplay}` : ""}${
     assignedByDisplay ? `\n  Assigned By (User ID): ${assignedByDisplay}` : ""
   }`;
+}
+
+/**
+ * Resolves project IDs to human-readable project names.
+ * Uses a single getProjects() call to build a lookup map (avoids N+1 API pattern).
+ *
+ * @param todoistClient - The Todoist API client
+ * @param projectIds - Array of project IDs to resolve
+ * @returns Map of projectId -> projectName
+ */
+export async function resolveProjectNames(
+  todoistClient: TodoistApi,
+  projectIds: string[]
+): Promise<Record<string, string>> {
+  const uniqueIds = [...new Set(projectIds.filter(Boolean))];
+  if (uniqueIds.length === 0) return {};
+
+  try {
+    // Single API call to get all projects, then build lookup map
+    const response = await todoistClient.getProjects();
+    const projects = extractArrayFromResponse<{ id: string; name: string }>(
+      response
+    );
+    const nameMap: Record<string, string> = {};
+    for (const id of uniqueIds) {
+      const project = projects.find((p) => p.id === id);
+      nameMap[id] = project ? project.name : "Unknown Project";
+    }
+    return nameMap;
+  } catch {
+    // Graceful fallback if project lookup fails
+    const fallback: Record<string, string> = {};
+    for (const id of uniqueIds) {
+      fallback[id] = "Unknown Project";
+    }
+    return fallback;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `resolveProjectNames()` utility that uses **1 `getProjects()` call** to build a lookup map (fixes the N+1 API pattern flagged in #76 review)
- Show human-readable project names in task output: `Project: Work` instead of `Project ID: 2203306141`
- Update `formatTaskForDisplay()` to accept optional `projectName` parameter
- Refactor `handleGetCompletedTasks()` to use shared utility instead of ad-hoc sequential loop

## Addresses review feedback from #76

- **N+1 fix**: `resolveProjectNames()` fetches all projects once with `getProjects()`, builds `Record<string, string>` map. Previous implementation called `getProject(id)` per unique project.
- **Completed tasks**: No longer depends on deprecated v9 `response.projects` field — uses the same shared utility as other handlers.

## Handlers Updated

| Handler | Before | After |
|---|---|---|
| `handleCreateTask` | `Project ID: xxx` | `Project: Name` |
| `handleGetTasks` (single) | No project shown | `Project: Name` |
| `handleGetTasks` (multi) | No project shown | `Project: Name` per task |
| `handleUpdateTask` | `New Project ID: xxx` | `New Project: Name` |
| `handleGetCompletedTasks` | Used `data.projects[id].name` (v9) | Uses `resolveProjectNames()` |

## Files Changed (4)

- `src/utils/api-helpers.ts` — new `resolveProjectNames()`, updated `formatTaskForDisplay()`
- `src/handlers/task/crud.ts` — project name resolution in create/get/update
- `src/handlers/task/completed.ts` — refactored to use shared utility
- `src/__tests__/task-handlers-update.test.ts` — updated for project name display

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 422 tests pass (24 suites)
- [x] `npm run lint` — 0 errors
- [x] Diff contains ONLY project name resolution (no pagination, no priority docs, no API migration)

Extracted from #76 per review feedback — focused on project name resolution only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)